### PR TITLE
Fix opening of info window of marker

### DIFF
--- a/src/Helper/Subscriber/Overlay/MarkerInfoWindowOpenSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/MarkerInfoWindowOpenSubscriber.php
@@ -88,6 +88,10 @@ class MarkerInfoWindowOpenSubscriber extends AbstractMarkerSubscriber
                     $rawEvent
                 ));
             }
+            if ($marker->hasInfoWindow() && $marker->getInfoWindow()->isOpen()) {
+                $event->addCode($formatter->renderCode($this->infoWindowOpenRenderer->render($marker->getInfoWindow(), $map, $marker)));
+                $marker->getInfoWindow()->setOpen(false);
+            }
         }
     }
 


### PR DESCRIPTION
This is a hotfix for https://github.com/egeloen/ivory-google-map/issues/279

The opening event of a info window of a marker needs the marker object! To prevent the adding of another event here:
https://github.com/bresam/ivory-google-map/blob/34139b5d7c496ceb30ad346c1c32bd1510cd36eb/src/Helper/Subscriber/Overlay/InfoWindowOpenSubscriber.php#L60
the `open` property of infoWindow needs to be reseted after adding the new event for the info window of a marker!