### PR TITLE
added labelOrigin to Icon

### DIFF
--- a/doc/overlay/icon.md
+++ b/doc/overlay/icon.md
@@ -86,3 +86,14 @@ use Ivory\GoogleMap\Base\Size;
 
 $icon->setScaledSize(new Size(20, 34));
 ```
+
+## Configure label origin
+
+If you want to update the label origin, you can use:
+
+``` php
+use Ivory\GoogleMap\Base\Point;
+
+$icon->setLabelOrigin(new Point(0, 0));
+
+```

--- a/src/Helper/Collector/Base/PointCollector.php
+++ b/src/Helper/Collector/Base/PointCollector.php
@@ -62,6 +62,10 @@ class PointCollector extends AbstractCollector
                 if ($icon->hasOrigin()) {
                     $points = $this->collectValue($icon->getOrigin(), $points);
                 }
+
+                if ($icon->hasLabelOrigin()) {
+                    $points = $this->collectValue($icon->getLabelOrigin(), $points);
+                }
             }
         }
 

--- a/src/Helper/Renderer/Overlay/IconRenderer.php
+++ b/src/Helper/Renderer/Overlay/IconRenderer.php
@@ -43,6 +43,10 @@ class IconRenderer extends AbstractJsonRenderer
             $jsonBuilder->setValue('[size]', $icon->getScaledSize()->getVariable(), false);
         }
 
+        if ($icon->hasLabelOrigin()) {
+            $jsonBuilder->setValue('[labelOrigin]', $icon->getLabelOrigin()->getVariable(), false);
+        }
+
         return $this->getFormatter()->renderObjectAssignment($icon, $jsonBuilder->build());
     }
 }

--- a/src/Overlay/Icon.php
+++ b/src/Overlay/Icon.php
@@ -53,6 +53,11 @@ class Icon implements VariableAwareInterface
     private $size;
 
     /**
+     * @var Point|null
+     */
+    private $labelOrigin;
+
+    /**
      * @param string $url
      */
     public function __construct(
@@ -60,13 +65,15 @@ class Icon implements VariableAwareInterface
         Point $anchor = null,
         Point $origin = null,
         Size $scaledSize = null,
-        Size $size = null
+        Size $size = null,
+        Point $labelOrigin = null
     ) {
         $this->setUrl($url);
         $this->setAnchor($anchor);
         $this->setOrigin($origin);
         $this->setScaledSize($scaledSize);
         $this->setSize($size);
+        $this->setLabelOrigin($labelOrigin);
     }
 
     /**
@@ -168,4 +175,26 @@ class Icon implements VariableAwareInterface
     {
         $this->size = $size;
     }
+
+    /**
+     * @return bool
+     */
+    public function hasLabelOrigin()
+    {
+        return null !== $this->labelOrigin;
+    }
+
+    /**
+     * @return Point|null
+     */
+    public function getLabelOrigin()
+    {
+        return $this->labelOrigin;
+    }
+
+    public function setLabelOrigin(Point $labelOrigin = null)
+    {
+        $this->labelOrigin = $labelOrigin;
+    }
+
 }


### PR DESCRIPTION
Hello,

when I added label to Marker which uses custom Icon (example code bellow) the label was not aligned correctly.
In [google maps documentation](https://developers.google.com/maps/documentation/javascript/reference/marker#Icon.labelOrigin) the Icon has option for that. With this pull request user can set position of label.

``` php
$marker = new Marker();
$marker->setIcon(new Icon($url));
$marker->setOption('label', ['text' => 'L', 'color' => 'white' ] );
```