### PR TITLE
feat: add support for symfony 6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,14 +19,14 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [7.2, 7.3, 7.4, 8.0]
+                php: [7.2, 7.3, 7.4, 8.0, 8.1, 8.2]
 
         env:
             APP_ENV: test
 
         steps:
             -
-                uses: actions/checkout@v2
+                uses: actions/checkout@v3
 
             -
                 name: Setup PHP
@@ -44,7 +44,7 @@ jobs:
 
             -
                 name: Cache Composer
-                uses: actions/cache@v2
+                uses: actions/cache@v3
                 with:
                     path: ${{ steps.composer-cache.outputs.dir }}
                     key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json **/composer.lock') }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
             -
                 name: Get Composer cache directory
                 id: composer-cache
-                run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             -
                 name: Cache Composer

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "ivory/json-builder": "^3.0",
+        "ivory/json-builder": "dev-feature/symfony-6",
         "symfony/event-dispatcher": "^5.4 || ^6.2"
     },
     "require-dev": {
@@ -46,9 +46,13 @@
         "psr-4": { "Ivory\\Tests\\GoogleMap\\": "tests/" }
     },
     "repositories": {
-    "repo-ivory-serializer": {
-        "type": "vcs",
-        "url": "git@github.com:Chris53897/ivory-serializer.git"
-    }
+        "repo-ivory-serializer": {
+            "type": "vcs",
+            "url": "git@github.com:Chris53897/ivory-serializer.git"
+        },
+        "repo-ivory-json-builder": {
+            "type": "vcs",
+            "url": "git@github.com:Chris53897/ivory-json-builder.git"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ivory/google-map",
-    "description": "Google Map API v3 integration for PHP ^7.0",
+    "description": "Google Map API v3 integration for PHP ^7.2",
     "keywords": [ "google", "map"],
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require-dev": {
         "ivory/serializer": "dev-master#99907d5",
-        "friendsofphp/php-cs-fixer": "^3.14",
+        "friendsofphp/php-cs-fixer": "^2.19 || ^3.14",
         "php-http/cache-plugin": "^1.7.5",
         "php-http/guzzle6-adapter": "^2.0",
         "phpunit/phpunit": "^8.5 || ^9.6",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "phpunit/phpunit": "^8.5 || ^9.6",
         "phpunit/phpunit-selenium": "^8.0 || ^9.0",
         "symfony/cache": "^5.4 || ^6.2",
-        "symfony/phpunit-bridge": "5.4 || ^6.2",
+        "symfony/phpunit-bridge": "^5.4 || ^6.2",
         "ext-json": "*"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/event-dispatcher": "^5.4 || ^6.2"
     },
     "require-dev": {
-        "ivory/serializer": "dev-master#99907d5",
+        "ivory/serializer": "dev-master#de27ada",
         "friendsofphp/php-cs-fixer": "^2.19 || ^3.14",
         "php-http/cache-plugin": "^1.7.5",
         "php-http/guzzle6-adapter": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/event-dispatcher": "^5.4 || ^6.2"
     },
     "require-dev": {
-        "ivory/serializer": "dev-master#de27ada",
+        "ivory/serializer": "dev-feature/php8",
         "friendsofphp/php-cs-fixer": "^2.19 || ^3.14",
         "php-http/cache-plugin": "^1.7.5",
         "php-http/guzzle6-adapter": "^2.0",
@@ -44,5 +44,11 @@
     },
     "autoload-dev": {
         "psr-4": { "Ivory\\Tests\\GoogleMap\\": "tests/" }
+    },
+    "repositories": {
+    "repo-ivory-serializer": {
+        "type": "vcs",
+        "url": "git@github.com:Chris53897/ivory-serializer.git"
+    }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,17 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "ivory/json-builder": "^3.0",
-        "symfony/event-dispatcher": "^5.0"
+        "symfony/event-dispatcher": "^5.4 || ^6.2"
     },
     "require-dev": {
-        "ivory/serializer": "^1.0",
-        "friendsofphp/php-cs-fixer": "^2.0",
-        "php-http/cache-plugin": "^1.4",
+        "ivory/serializer": "dev-master#99907d5",
+        "friendsofphp/php-cs-fixer": "^3.14",
+        "php-http/cache-plugin": "^1.7.5",
         "php-http/guzzle6-adapter": "^2.0",
-        "phpunit/phpunit": "^8.0",
-        "phpunit/phpunit-selenium": "^8.0",
-        "symfony/cache": "^5.0",
-        "symfony/phpunit-bridge": "^5.0",
+        "phpunit/phpunit": "^8.5 || ^9.6",
+        "phpunit/phpunit-selenium": "^8.0 || ^9.0",
+        "symfony/cache": "^5.4 || ^6.2",
+        "symfony/phpunit-bridge": "5.4 || ^6.2",
         "ext-json": "*"
     },
     "suggest": {

--- a/phpunit.ci.xml
+++ b/phpunit.ci.xml
@@ -1,24 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<phpunit colors="true" bootstrap="tests/autoload.php">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         colors="true"
+         bootstrap="tests/autoload.php"
+>
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+    </php>
+
     <testsuites>
         <testsuite name="Ivory Google Map Test Suite">
             <directory suffix="Test.php">./tests/</directory>
         </testsuite>
     </testsuites>
+
     <php>
         <server name="BROWSER_NAME" value="chrome" />
         <server name="CACHE_PATH" value="tests/.cache" />
     </php>
+
     <filter>
         <whitelist>
             <directory suffix=".php">./src/</directory>
         </whitelist>
     </filter>
+
     <groups>
         <exclude>
             <!-- Temporarily disabled due to incorrect batch execution errors -->
             <group>functional</group>
         </exclude>
     </groups>
+
 </phpunit>

--- a/src/Utility/VariableAwareTrait.php
+++ b/src/Utility/VariableAwareTrait.php
@@ -28,7 +28,7 @@ trait VariableAwareTrait
     {
         if (null === $this->variable) {
             $prefix = strtolower(substr(strrchr(get_class($this), '\\'), 1));
-            $this->variable = $prefix.substr_replace(uniqid(null, true), '', 14, 1);
+            $this->variable = $prefix.substr_replace(uniqid('', true), '', 14, 1);
         }
 
         return $this->variable;

--- a/tests/Utility/VariableAwareTest.php
+++ b/tests/Utility/VariableAwareTest.php
@@ -36,7 +36,7 @@ class VariableAwareTest extends TestCase
     public function testDefaultState()
     {
         $this->assertIsString($this->variableAware->getVariable());
-        $this->assertRegExp('/^variableawaremock[a-z0-9]*$/', $this->variableAware->getVariable());
+        $this->assertMatchesRegularExpression('/^variableawaremock[a-z0-9]*$/', $this->variableAware->getVariable());
     }
 
     public function testVariable()

--- a/tests/Utility/VariableAwareTest.php
+++ b/tests/Utility/VariableAwareTest.php
@@ -36,7 +36,10 @@ class VariableAwareTest extends TestCase
     public function testDefaultState()
     {
         $this->assertIsString($this->variableAware->getVariable());
-        $this->assertMatchesRegularExpression('/^variableawaremock[a-z0-9]*$/', $this->variableAware->getVariable());
+
+        if(method_exists($this, 'assertMatchesRegularExpression'))
+        {$this->assertMatchesRegularExpression('/^variableawaremock[a-z0-9]*$/', $this->variableAware->getVariable());}
+        else{$this->assertRegExp('/^variableawaremock[a-z0-9]*$/', $this->variableAware->getVariable());}
     }
 
     public function testVariable()


### PR DESCRIPTION
temp, see
https://github.com/bresam/ivory-serializer/pull/4

- fix ci deprecations
- add testruns for php 8.1 and 8.2
- fix warning for uniqid() with null
- make one test runable in phpunit 8 and 9
- adjust phpunit config file to pass tests without changing all remaing direct deprecations