### PR TITLE
feat: support symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,20 +17,20 @@
     ],
     "require": {
         "php": "^8.0",
-        "doctrine/annotations": "^1.13 || ^2.0",
-        "symfony/event-dispatcher": "^5.0 || ^6.0 || ^7.0",
-        "symfony/serializer": "^5.0 || ^6.0 || ^7.0",
-        "symfony/property-access": "^5.0 || ^6.0 || ^7.0",
-        "phpdocumentor/reflection-docblock": "^5.3"
+        "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
+        "symfony/serializer": "^5.4 || ^6.0 || ^7.0",
+        "symfony/property-access": "^5.4 || ^6.0 || ^7.0",
+        "phpdocumentor/reflection-docblock": "^5.3",
+        "php-http/message-factory": "^1.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.0",
-        "php-http/cache-plugin": "^1.4",
-        "php-http/guzzle6-adapter": "^2.0",
-        "phpunit/phpunit": "^8.5 || ^9.6",
-        "phpunit/phpunit-selenium": "^8.0 || ^9.0",
-        "symfony/cache": "^5.0 || ^6.0 || ^7.0",
-        "symfony/phpunit-bridge": "^5.0 || ^6.0 || ^7.0",
+        "friendsofphp/php-cs-fixer": "^3.49",
+        "php-http/cache-plugin": "^2.0",
+        "php-http/guzzle7-adapter": "^1.0",
+        "phpunit/phpunit": "^9.6.16",
+        "phpunit/phpunit-selenium": "^9.0",
+        "symfony/cache": "^5.4 || ^6.0 || ^7.0",
+        "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0",
         "ext-json": "*"
     },
     "suggest": {

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -29,11 +29,11 @@ If you want to use a service (geocoder, direction, ...), you will need an http c
 [Httplug](http://httplug.io/) which is an http client abstraction library:
 
 ``` bash
-$ composer require php-http/guzzle6-adapter
+$ composer require php-http/guzzle7-adapter
 $ composer require php-http/message
 ```
 
-Here, I have chosen to use [Guzzle6](http://docs.guzzlephp.org/en/latest/psr7.html) but since Httplug supports the 
+Here, I have chosen to use [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) but since Httplug supports the 
 most popular http clients, you can install your preferred one instead.
 
 ### Ivory Serializer

--- a/doc/service/direction/direction.md
+++ b/doc/service/direction/direction.md
@@ -17,14 +17,14 @@ First of all, if you want to route a direction, you will need to build a directi
 
 ``` php
 use Ivory\GoogleMap\Service\Direction\DirectionService;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $direction = new DirectionService(new Client(), new GuzzleMessageFactory());
 ```
 
 The direction constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. Here, 
-I have chosen to use the [Guzzle6](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle message 
+I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle message 
 factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
 
 The direction constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to use it 
@@ -33,7 +33,7 @@ in order to configure a PSR-6 cache pool and so avoid parsing the built-in metad
 ``` php
 use Ivory\GoogleMap\Service\Direction\DirectionService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $direction = new DirectionService(

--- a/doc/service/distance_matrix/distance_matrix.md
+++ b/doc/service/distance_matrix/distance_matrix.md
@@ -19,14 +19,14 @@ First of all, if you want to process a distance matrix, you will need to build a
 
 ``` php
 use Ivory\GoogleMap\Service\DistanceMatrix\DistanceMatrixService;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $distanceMatrix = new DistanceMatrixService(new Client(), new GuzzleMessageFactory());
 ```
 
 The distance matrix constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. 
-Here, I have chosen to use the [Guzzle6](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
+Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
 message factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
 
 The distance matrix constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to 
@@ -35,7 +35,7 @@ use it in order to configure a PSR-6 cache pool and so avoid parsing the built-i
 ``` php
 use Ivory\GoogleMap\Service\DistanceMatrix\DistanceMatrixService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $distanceMatrix = new DistanceMatrixService(

--- a/doc/service/elevation/elevation.md
+++ b/doc/service/elevation/elevation.md
@@ -16,14 +16,14 @@ First of all, if you want to process an elevation, you will need to build an ele
 
 ``` php
 use Ivory\GoogleMap\Service\Elevation\ElevationService;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $elevation = new ElevationService(new Client(), new GuzzleMessageFactory());
 ```
 
 The elevation constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. 
-Here, I have chosen to use the [Guzzle6](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
+Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
 message factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
 
 The elevation constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to use it in 
@@ -32,7 +32,7 @@ order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata
 ``` php
 use Ivory\GoogleMap\Service\Elevation\ElevationService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $elevation = new ElevationService(

--- a/doc/service/geocoder/geocoder.md
+++ b/doc/service/geocoder/geocoder.md
@@ -17,14 +17,14 @@ First of all, if you want to geocode a position, you will need to build a geocod
 
 ``` php
 use Ivory\GoogleMap\Service\Geocoder\GeocoderService;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $geocoder = new GeocoderService(new Client(), new GuzzleMessageFactory());
 ```
 
 The geocoder constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. Here, 
-I have chosen to use the [Guzzle6](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle message 
+I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle message 
 factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
 
 The geocoder constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to use it in 
@@ -33,7 +33,7 @@ order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata
 ``` php
 use Ivory\GoogleMap\Service\Geocoder\GeocoderService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $geocoder = new GeocoderService(

--- a/doc/service/place/autocomplete/place_autocomplete.md
+++ b/doc/service/place/autocomplete/place_autocomplete.md
@@ -23,14 +23,14 @@ let's go:
 
 ``` php
 use Ivory\GoogleMap\Service\Direction\Place\Autocomplete\PlaceAutocompleteService;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $autocomplete = new PlaceAutocompleteService(new Client(), new GuzzleMessageFactory());
 ```
 
 The Place Autocomplete constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. 
-Here, I have chosen to use the [Guzzle6](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
+Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
 message factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
 
 The Place Autocomplete constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to 
@@ -39,7 +39,7 @@ use it in order to configure a PSR-6 cache pool and so avoid parsing the built-i
 ``` php
 use Ivory\GoogleMap\Service\Place\Autocomplete\PlaceAutocompleteService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $autocomplete = new PlaceAutocompleteService(

--- a/doc/service/place/detail/place_detail.md
+++ b/doc/service/place/detail/place_detail.md
@@ -17,14 +17,14 @@ First of all, if you want to process a place detail, you will need to build a pl
 
 ``` php
 use Ivory\GoogleMap\Service\Place\Detail\PlaceDetailService;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $detail = new PlaceDetailService(new Client(), new GuzzleMessageFactory());
 ```
 
 The Place Detail constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. 
-Here, I have chosen to use the [Guzzle6](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
+Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
 message factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
 
 The Place Detail constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to 
@@ -33,7 +33,7 @@ use it in order to configure a PSR-6 cache pool and so avoid parsing the built-i
 ``` php
 use Ivory\GoogleMap\Service\Place\Detail\PlaceDetailService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $detail = new PlaceDetailService(

--- a/doc/service/place/search/place_search.md
+++ b/doc/service/place/search/place_search.md
@@ -16,14 +16,14 @@ First of all, if you want to process a place search, you will need to build a pl
 
 ``` php
 use Ivory\GoogleMap\Service\Place\Search\PlaceSearchService;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $search = new PlaceSearchService(new Client(), new GuzzleMessageFactory());
 ```
 
 The Place Search constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. 
-Here, I have chosen to use the [Guzzle6](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
+Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
 message factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
 
 The Place Detail constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to 
@@ -32,7 +32,7 @@ use it in order to configure a PSR-6 cache pool and so avoid parsing the built-i
 ``` php
 use Ivory\GoogleMap\Service\Place\Search\PlaceSearchService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $search = new PlaceSearchService(

--- a/doc/service/service.md
+++ b/doc/service/service.md
@@ -7,12 +7,12 @@ All services (direction, distance matrix, geocoder, ...) share common features.
 If you want to update the service http client, you can use:
 
 ``` php
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 
 $service->setClient(new Client());
 ```
 
-Here, I have chosen to use the [Guzzle6](http://docs.guzzlephp.org/en/latest/psr7.html) client but since 
+Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client but since 
 [Httplug](http://httplug.io/) supports the most popular http clients, you can choose you preferred one instead.
 
 ## Configure http plugins
@@ -37,7 +37,7 @@ Here, I have chosen to use the Symfony Cache PSR-6 component but you can choose 
 Then, create a plugin client:
 
 ``` php
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Client\Common\Plugin\CachePlugin;
 use Http\Client\Common\Plugin\ErrorPlugin as HttpErrorPlugin;
 use Http\Client\Common\Plugin\RetryPlugin;
@@ -74,7 +74,7 @@ use Http\Message\MessageFactory\GuzzleMessageFactory;
 $service->setMessageFactory(new GuzzleMessageFactory());
 ```
 
-Here, I have chosen to use the [Guzzle6](http://docs.guzzlephp.org/en/latest/psr7.html) message factory but since 
+Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) message factory but since 
 [Httplug](http://httplug.io/) supports the most popular http clients, you can choose you preferred one instead.
 
 ## Configure serializer

--- a/doc/service/timezone/timezone.md
+++ b/doc/service/timezone/timezone.md
@@ -15,14 +15,14 @@ First of all, if you want to process a timezone, you will need to build a timezo
 
 ``` php
 use Ivory\GoogleMap\Service\TimeZone\TimeZoneService;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $timeZone = new TimeZoneService(new Client(), new GuzzleMessageFactory());
 ```
 
 The timezone constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. Here, 
-I have chosen to use the [Guzzle6](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle message 
+I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle message 
 factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
 
 The timezone constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to use it in 
@@ -31,7 +31,7 @@ order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata
 ``` php
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
 use Ivory\GoogleMap\Service\TimeZone\TimeZoneService;
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 
 $timeZone = new TimeZoneService(

--- a/src/Base/Coordinate.php
+++ b/src/Base/Coordinate.php
@@ -24,15 +24,12 @@ class Coordinate implements VariableAwareInterface
 {
     use VariableAwareTrait;
 
-    /** @var float */
     #[SerializedName('lat')]
     private float $latitude;
 
-    /** @var float */
     #[SerializedName('lng')]
     private float $longitude;
 
-    /** @var bool */
     private bool $noWrap;
 
     public function __construct(float $latitude = 0.0, float $longitude = 0.0, bool $noWrap = true)
@@ -42,15 +39,11 @@ class Coordinate implements VariableAwareInterface
         $this->setNoWrap($noWrap);
     }
 
-    /**
-     * @return float
-     */
-    public function getLatitude()
+    public function getLatitude(): float
     {
         return $this->latitude;
     }
 
-    /** @param float $latitude */
     public function setLatitude(float $latitude): void
     {
         $this->latitude = $latitude;
@@ -61,19 +54,16 @@ class Coordinate implements VariableAwareInterface
         return $this->longitude;
     }
 
-    /** @param float $longitude */
     public function setLongitude(float $longitude): void
     {
         $this->longitude = $longitude;
     }
 
-    /** @return bool */
     public function isNoWrap(): bool
     {
         return $this->noWrap;
     }
 
-    /** @param bool $noWrap */
     public function setNoWrap(bool $noWrap): void
     {
         $this->noWrap = $noWrap;

--- a/src/Base/Point.php
+++ b/src/Base/Point.php
@@ -23,21 +23,10 @@ class Point implements VariableAwareInterface
 {
     use VariableAwareTrait;
 
-    /**
-     * @var float
-     */
-    private $x;
+    private float $x;
+    private float $y;
 
-    /**
-     * @var float
-     */
-    private $y;
-
-    /**
-     * @param float $x
-     * @param float $y
-     */
-    public function __construct($x = 0.0, $y = 0.0)
+    public function __construct(float $x = 0.0, float $y = 0.0)
     {
         $this->setX($x);
         $this->setY($y);

--- a/src/Service/Direction/DirectionService.php
+++ b/src/Service/Direction/DirectionService.php
@@ -16,6 +16,7 @@ use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\Direction\Request\DirectionRequestInterface;
 use Ivory\GoogleMap\Service\Direction\Response\DirectionResponse;
+use Psr\Http\Client\ClientExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -31,6 +32,9 @@ class DirectionService extends AbstractSerializableService
         parent::__construct('https://maps.googleapis.com/maps/api/directions', $client, $messageFactory, $serializer);
     }
 
+    /**
+     * @throws ClientExceptionInterface
+     */
     public function route(DirectionRequestInterface $request): DirectionResponse
     {
         $httpRequest = $this->createRequest($request);

--- a/src/Service/Plugin/ErrorPlugin.php
+++ b/src/Service/Plugin/ErrorPlugin.php
@@ -60,7 +60,7 @@ class ErrorPlugin implements Plugin
 
         foreach (self::$errors as $error => $exception) {
             foreach (self::$placeholders as $placeholder) {
-                if (false !== strpos($body, sprintf($placeholder, $error))) {
+                if (str_contains($body, sprintf($placeholder, $error))) {
                     throw new $exception($error, $request, $response);
                 }
             }

--- a/src/Service/Serializer/GoogleDateTimeNormalizer.php
+++ b/src/Service/Serializer/GoogleDateTimeNormalizer.php
@@ -7,11 +7,10 @@ namespace Ivory\GoogleMap\Service\Serializer;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;
-use Symfony\Component\Serializer\Normalizer\CacheableSupportsMethodInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
-class GoogleDateTimeNormalizer implements NormalizerInterface, DenormalizerInterface, CacheableSupportsMethodInterface
+class GoogleDateTimeNormalizer implements NormalizerInterface, DenormalizerInterface
 {
     public const FORMAT_KEY = 'datetime_format';
     public const TIMEZONE_KEY = 'datetime_timezone';
@@ -39,12 +38,8 @@ class GoogleDateTimeNormalizer implements NormalizerInterface, DenormalizerInter
 
     /**
      * {@inheritdoc}
-     *
-     * @return string
-     *
-     * @throws InvalidArgumentException
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize(mixed $object, string $format = null, array $context = []): float|int|bool|\ArrayObject|array|string|null
     {
         if (!$object instanceof \DateTimeInterface) {
             throw new InvalidArgumentException('The object must implement the "\DateTimeInterface".');
@@ -64,7 +59,7 @@ class GoogleDateTimeNormalizer implements NormalizerInterface, DenormalizerInter
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof \DateTimeInterface;
     }
@@ -76,7 +71,7 @@ class GoogleDateTimeNormalizer implements NormalizerInterface, DenormalizerInter
      *
      * @throws NotNormalizableValueException
      */
-    public function denormalize($data, string $type, string $format = null, array $context = [])
+    public function denormalize($data, string $type, string $format = null, array $context = []): mixed
     {
         $dateTimeFormat = $context[self::FORMAT_KEY] ?? null;
         $timezone = $this->getTimezone($context);
@@ -119,7 +114,7 @@ class GoogleDateTimeNormalizer implements NormalizerInterface, DenormalizerInter
     /**
      * {@inheritdoc}
      */
-    public function supportsDenormalization($data, string $type, string $format = null)
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return isset(self::SUPPORTED_TYPES[$type]);
     }
@@ -157,5 +152,10 @@ class GoogleDateTimeNormalizer implements NormalizerInterface, DenormalizerInter
         }
 
         return $dateTimeZone instanceof \DateTimeZone ? $dateTimeZone : new \DateTimeZone($dateTimeZone);
+    }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        // TODO: Implement getSupportedTypes() method.
     }
 }

--- a/src/Service/Serializer/SerializerBuilder.php
+++ b/src/Service/Serializer/SerializerBuilder.php
@@ -18,7 +18,7 @@ use Symfony\Component\PropertyInfo\PropertyInfoExtractor;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Encoder\XmlEncoder;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
-use Symfony\Component\Serializer\Mapping\Loader\AnnotationLoader;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Serializer\NameConverter\MetadataAwareNameConverter;
 use Symfony\Component\Serializer\Normalizer\ArrayDenormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
@@ -31,7 +31,7 @@ class SerializerBuilder
 {
     public static function create(): Serializer
     {
-        $classMetadataFactory = new ClassMetadataFactory(new AnnotationLoader(new AnnotationReader()));
+        $classMetadataFactory = new ClassMetadataFactory(new AttributeLoader());
         $metadataAwareNameConverter = new MetadataAwareNameConverter($classMetadataFactory);
         $extractor = new PropertyInfoExtractor([], [
             new PhpDocExtractor(),

--- a/tests/Base/BoundTest.php
+++ b/tests/Base/BoundTest.php
@@ -23,10 +23,7 @@ use PHPUnit\Framework\TestCase;
  */
 class BoundTest extends TestCase
 {
-    /**
-     * @var Bound
-     */
-    private $bound;
+    private Bound $bound;
 
     /**
      * {@inheritdoc}

--- a/tests/Base/CoordinateTest.php
+++ b/tests/Base/CoordinateTest.php
@@ -20,10 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CoordinateTest extends TestCase
 {
-    /**
-     * @var Coordinate
-     */
-    private $coordinate;
+    private Coordinate $coordinate;
 
     /**
      * {@inheritdoc}

--- a/tests/Base/PointTest.php
+++ b/tests/Base/PointTest.php
@@ -20,10 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PointTest extends TestCase
 {
-    /**
-     * @var Point
-     */
-    private $point;
+    private Point $point;
 
     /**
      * {@inheritdoc}

--- a/tests/Base/SizeTest.php
+++ b/tests/Base/SizeTest.php
@@ -20,10 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class SizeTest extends TestCase
 {
-    /**
-     * @var Size
-     */
-    private $size;
+    private Size $size;
 
     /**
      * {@inheritdoc}

--- a/tests/Event/EventManagerTest.php
+++ b/tests/Event/EventManagerTest.php
@@ -21,10 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class EventManagerTest extends TestCase
 {
-    /**
-     * @var EventManager
-     */
-    private $eventManager;
+    private EventManager $eventManager;
 
     /**
      * {@inheritdoc}

--- a/tests/Helper/Functional/StaticMapFunctionalTest.php
+++ b/tests/Helper/Functional/StaticMapFunctionalTest.php
@@ -11,7 +11,7 @@
 
 namespace Ivory\Tests\GoogleMap\Helper\Functional;
 
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Client\Common\Plugin\CachePlugin;
 use Http\Client\Common\PluginClient;
 use Http\Client\HttpClient;

--- a/tests/Service/AbstractFunctionalServiceTest.php
+++ b/tests/Service/AbstractFunctionalServiceTest.php
@@ -11,7 +11,7 @@
 
 namespace Ivory\Tests\GoogleMap\Service;
 
-use Http\Adapter\Guzzle6\Client;
+use Http\Adapter\Guzzle7\Client;
 use Http\Client\Common\Plugin\ErrorPlugin as HttpErrorPlugin;
 use Http\Client\Common\Plugin\HistoryPlugin;
 use Http\Client\Common\Plugin\RetryPlugin;


### PR DESCRIPTION
https://github.com/bresam/ivory-google-map/issues/25

Is there a replacement for CacheableSupportsMethodInterface
Is it needed?

Do not trust the ci for support of all symony versions. See
https://github.com/bresam/ivory-google-map/issues/23