### PR TITLE
feat: drop support for php < 8,1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,12 +20,9 @@ jobs:
                 stability: [ prefer-stable ]
                 symfony-version: [ '7.0.*' ]
                 include:
-                  - php: '8.0'
-                    symfony-version: 5.4.*
+                  - php: '8.1'
+                    symfony-version: 6.4.*
                     stability: prefer-lowest
-                  - php: '8.0'
-                    symfony-version: 5.4.*
-                    stability: prefer-stable
                   - php: '8.1'
                     symfony-version: 6.4.*
                     stability: prefer-stable

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ivory/google-map",
-    "description": "Google Map API v3 integration for PHP ^8.0",
+    "description": "Google Map API v3 integration for PHP",
     "keywords": [ "google", "map"],
     "license": "MIT",
     "authors": [
@@ -16,10 +16,10 @@
         }
     ],
     "require": {
-        "php": "^8.0",
-        "symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
-        "symfony/serializer": "^5.4 || ^6.0 || ^7.0",
-        "symfony/property-access": "^5.4 || ^6.0 || ^7.0",
+        "php": "^8.1",
+        "symfony/event-dispatcher": "^6.4 || ^7.0",
+        "symfony/serializer": "^6.4 || ^7.0",
+        "symfony/property-access": "^6.4 || ^7.0",
         "phpdocumentor/reflection-docblock": "^5.3",
         "php-http/message-factory": "^1.1"
     },
@@ -29,8 +29,8 @@
         "php-http/guzzle7-adapter": "^1.0",
         "phpunit/phpunit": "^9.6.16",
         "phpunit/phpunit-selenium": "^9.0",
-        "symfony/cache": "^5.4 || ^6.0 || ^7.0",
-        "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0",
+        "symfony/cache": "^6.4 || ^7.0",
+        "symfony/phpunit-bridge": "^6.4 || ^7.0",
         "ext-json": "*"
     },
     "suggest": {


### PR DESCRIPTION
See https://github.com/bresam/ivory-google-map/issues/25#issuecomment-1954903858

drop support for symfony < 6.4

Align versions with [the symfony bundle for this repo](https://github.com/bresam/ivory-google-map-bundle)

Goal: Keep maintainence work to the minimum. Enables PHP 8.1 Features