### PR TITLE
feat: fix test deprecations,

### DIFF
--- a/src/Service/Place/Search/Response/PlaceSearchResponseIterator.php
+++ b/src/Service/Place/Search/Response/PlaceSearchResponseIterator.php
@@ -43,17 +43,19 @@ class PlaceSearchResponseIterator implements \Iterator
     /**
      * {@inheritdoc}
      */
-    public function current()
+    public function current(): mixed
     {
         if ($this->valid()) {
             return $this->responses[$this->position];
         }
+
+        return null;
     }
 
-    /**
+    /**s
      * {@inheritdoc}
      */
-    public function next()
+    public function next(): void
     {
         if (!$this->valid()) {
             return;
@@ -78,7 +80,7 @@ class PlaceSearchResponseIterator implements \Iterator
     /**
      * {@inheritdoc}
      */
-    public function key()
+    public function key(): mixed
     {
         return $this->position;
     }
@@ -86,7 +88,7 @@ class PlaceSearchResponseIterator implements \Iterator
     /**
      * {@inheritdoc}
      */
-    public function valid()
+    public function valid(): bool
     {
         return $this->position < count($this->responses);
     }
@@ -94,7 +96,7 @@ class PlaceSearchResponseIterator implements \Iterator
     /**
      * {@inheritdoc}
      */
-    public function rewind()
+    public function rewind(): void
     {
         $this->position = 0;
     }

--- a/tests/Service/AbstractFunctionalServiceTest.php
+++ b/tests/Service/AbstractFunctionalServiceTest.php
@@ -89,15 +89,9 @@ abstract class AbstractFunctionalServiceTest extends TestCase
         ]);
     }
 
-    /**
-     * @param string $key
-     * @param string $value
-     *
-     * @return \DateTime
-     */
-    protected function getDateTime($key, $value = 'now')
+    protected function getDateTime(string $key, string $value = 'now'): \DateTime
     {
-        $item = $this->pool->getItem(sha1(get_class().'::'.$key));
+        $item = $this->pool->getItem(sha1(__CLASS__ .'::'.$key));
 
         if (!$item->isHit()) {
             $item->set(new \DateTime($value));

--- a/tests/Service/DistanceMatrix/DistanceMatrixServiceUnitTest.php
+++ b/tests/Service/DistanceMatrix/DistanceMatrixServiceUnitTest.php
@@ -82,7 +82,6 @@ class DistanceMatrixServiceUnitTest extends AbstractUnitServiceTest
             ->with(
                 $this->identicalTo($result),
                 $this->identicalTo(DistanceMatrixResponse::class),
-                $this->identicalTo($this->service->getFormat()),
             )
             ->willReturn($response = $this->createDistanceMatrixResponseMock());
 

--- a/tests/Service/Elevation/ElevationServiceUnitTest.php
+++ b/tests/Service/Elevation/ElevationServiceUnitTest.php
@@ -82,7 +82,6 @@ class ElevationServiceUnitTest extends AbstractUnitServiceTest
             ->with(
                 $this->identicalTo($result),
                 $this->identicalTo(ElevationResponse::class),
-                $this->identicalTo($this->service->getFormat())
             )
             ->willReturn($response = $this->createElevationResponseMock());
 

--- a/tests/Service/Geocoder/GeocoderServiceUnitTest.php
+++ b/tests/Service/Geocoder/GeocoderServiceUnitTest.php
@@ -82,7 +82,6 @@ class GeocoderServiceUnitTest extends AbstractUnitServiceTest
             ->with(
                 $this->identicalTo($result),
                 $this->identicalTo(GeocoderResponse::class),
-                $this->identicalTo($this->service->getFormat()),
             )
             ->willReturn($response = $this->createGeocoderResponseMock());
 

--- a/tests/Service/Place/Autocomplete/PlaceAutocompleteServiceUnitTest.php
+++ b/tests/Service/Place/Autocomplete/PlaceAutocompleteServiceUnitTest.php
@@ -87,7 +87,6 @@ class PlaceAutocompleteServiceUnitTest extends AbstractUnitServiceTest
             ->with(
                 $this->identicalTo($result),
                 $this->identicalTo(PlaceAutocompleteResponse::class),
-                $this->identicalTo($this->service->getFormat()),
             )
             ->willReturn($response = $this->createPlaceAutocompleteResponseMock());
 

--- a/tests/Service/Place/Detail/PlaceDetailServiceUnitTest.php
+++ b/tests/Service/Place/Detail/PlaceDetailServiceUnitTest.php
@@ -82,7 +82,6 @@ class PlaceDetailServiceUnitTest extends AbstractUnitServiceTest
             ->with(
                 $this->identicalTo($result),
                 $this->identicalTo(PlaceDetailResponse::class),
-                $this->identicalTo($this->service->getFormat()),
             )
             ->willReturn($response = $this->createPlaceDetailResponseMock());
 

--- a/tests/Service/Place/Search/PlaceSearchServiceTest.php
+++ b/tests/Service/Place/Search/PlaceSearchServiceTest.php
@@ -128,7 +128,6 @@ class PlaceSearchServiceTest extends AbstractPlaceSerializableServiceTest
     {
         $request = $this->createTextRequest();
 
-        $this->service->setFormat('json');
         $iterator = $this->service->process($request);
 
         $this->assertPlaceSearchIterator($iterator, $request);
@@ -139,7 +138,6 @@ class PlaceSearchServiceTest extends AbstractPlaceSerializableServiceTest
         $request = $this->createTextRequest();
         $request->setLocation(new Coordinate(50.637133, 3.063657));
 
-        $this->service->setFormat('json');
         $iterator = $this->service->process($request);
 
         $this->assertPlaceSearchIterator($iterator, $request);
@@ -151,7 +149,6 @@ class PlaceSearchServiceTest extends AbstractPlaceSerializableServiceTest
         $request->setLocation(new Coordinate(50.637133, 3.063657));
         $request->setRadius(1000);
 
-        $this->service->setFormat('json');
         $iterator = $this->service->process($request);
 
         $this->assertPlaceSearchIterator($iterator, $request);
@@ -172,7 +169,6 @@ class PlaceSearchServiceTest extends AbstractPlaceSerializableServiceTest
         $request = $this->createTextRequest('Pizza in Lille');
         $request->setMaxPrice(PriceLevel::MODERATE);
 
-        $this->service->setFormat('json');
         $iterator = $this->service->process($request);
 
         $this->assertPlaceSearchIterator($iterator, $request);
@@ -183,7 +179,6 @@ class PlaceSearchServiceTest extends AbstractPlaceSerializableServiceTest
         $request = $this->createTextRequest();
         $request->setOpenNow(true);
 
-        $this->service->setFormat('json');
         $iterator = $this->service->process($request);
 
         $this->assertPlaceSearchIterator($iterator, $request);
@@ -204,7 +199,6 @@ class PlaceSearchServiceTest extends AbstractPlaceSerializableServiceTest
         $request = $this->createTextRequest();
         $request->setLanguage('fr');
 
-        $this->service->setFormat('json');
         $iterator = $this->service->process($request);
 
         $this->assertPlaceSearchIterator($iterator, $request);
@@ -224,7 +218,6 @@ class PlaceSearchServiceTest extends AbstractPlaceSerializableServiceTest
     {
         $request = $this->createTextRequest('Church in Lille');
 
-        $this->service->setFormat('json');
         $iterator = $this->service->process($request);
 
         $this->assertPlaceSearchIterator($iterator, $request);

--- a/tests/Service/Place/Search/PlaceSearchServiceUnitTest.php
+++ b/tests/Service/Place/Search/PlaceSearchServiceUnitTest.php
@@ -87,7 +87,6 @@ class PlaceSearchServiceUnitTest extends AbstractUnitServiceTest
             ->with(
                 $this->identicalTo($result),
                 $this->identicalTo(PlaceSearchResponse::class),
-                $this->identicalTo($this->service->getFormat())
             )
             ->willReturn($response = $this->createPlaceSearchResponseMock());
 

--- a/tests/Service/SerializableServiceTest.php
+++ b/tests/Service/SerializableServiceTest.php
@@ -76,7 +76,6 @@ class SerializableServiceTest extends TestCase
         $this->assertSame($this->client, $this->service->getClient());
         $this->assertSame($this->messageFactory, $this->service->getMessageFactory());
         $this->assertSame($this->serializer, $this->service->getSerializer());
-        $this->assertSame(AbstractSerializableService::FORMAT_JSON, $this->service->getFormat());
         $this->assertFalse($this->service->hasKey());
         $this->assertNull($this->service->getKey());
         $this->assertFalse($this->service->hasBusinessAccount());

--- a/tests/Service/TimeZone/TimeZoneServiceUnitTest.php
+++ b/tests/Service/TimeZone/TimeZoneServiceUnitTest.php
@@ -81,8 +81,7 @@ class TimeZoneServiceUnitTest extends AbstractUnitServiceTest
             ->method('deserialize')
             ->with(
                 $this->identicalTo($result),
-                $this->identicalTo(TimeZoneResponse::class),
-                $this->identicalTo($this->service->getFormat())
+                $this->identicalTo(TimeZoneResponse::class)
             )
             ->willReturn($response = $this->createTimeZoneResponseMock());
 


### PR DESCRIPTION
add php strong types to fix deprecations for iterator.

I am not sure about this line https://github.com/bresam/ivory-google-map/compare/v6...Chris53897:feature/fix-test-deprecations?expand=1#diff-134d47e6ecf7399eee838a8140c396f4f3b8535fab451ed7b2a7bdbd0ce678aeR52

After that, deprecation messages are down to 1 remaining. (should be done in an seperate PR)