### PR TITLE
fix php8 return types

### DIFF
--- a/src/Base/Point.php
+++ b/src/Base/Point.php
@@ -42,6 +42,7 @@ class Point implements VariableAwareInterface
 
     /**
      * @param float $x
+     * @return void
      */
     public function setX($x)
     {
@@ -58,6 +59,7 @@ class Point implements VariableAwareInterface
 
     /**
      * @param float $y
+     * @return void
      */
     public function setY($y)
     {

--- a/src/Base/Size.php
+++ b/src/Base/Size.php
@@ -67,6 +67,7 @@ class Size implements VariableAwareInterface
 
     /**
      * @param float $width
+     * @return void
      */
     public function setWidth($width)
     {
@@ -83,6 +84,7 @@ class Size implements VariableAwareInterface
 
     /**
      * @param float $height
+     * @return void
      */
     public function setHeight($height)
     {
@@ -115,6 +117,7 @@ class Size implements VariableAwareInterface
 
     /**
      * @param string|null $widthUnit
+     * @return void
      */
     public function setWidthUnit($widthUnit = null)
     {
@@ -139,6 +142,7 @@ class Size implements VariableAwareInterface
 
     /**
      * @param string|null $heightUnit
+     * @return void
      */
     public function setHeightUnit($heightUnit = null)
     {

--- a/src/Control/ControlManager.php
+++ b/src/Control/ControlManager.php
@@ -66,7 +66,9 @@ class ControlManager
     {
         return $this->fullscreenControl;
     }
-
+    /**
+     * @return void
+     */
     public function setFullscreenControl(?FullscreenControl $fullscreenControl = null)
     {
         $this->fullscreenControl = $fullscreenControl;
@@ -87,7 +89,9 @@ class ControlManager
     {
         return $this->mapTypeControl;
     }
-
+    /**
+     * @return void
+     */
     public function setMapTypeControl(?MapTypeControl $mapTypeControl = null)
     {
         $this->mapTypeControl = $mapTypeControl;
@@ -108,7 +112,9 @@ class ControlManager
     {
         return $this->rotateControl;
     }
-
+    /**
+     * @return void
+     */
     public function setRotateControl(?RotateControl $rotateControl = null)
     {
         $this->rotateControl = $rotateControl;
@@ -129,7 +135,9 @@ class ControlManager
     {
         return $this->scaleControl;
     }
-
+    /**
+     * @return void
+     */
     public function setScaleControl(?ScaleControl $scaleControl = null)
     {
         $this->scaleControl = $scaleControl;
@@ -150,7 +158,9 @@ class ControlManager
     {
         return $this->streetViewControl;
     }
-
+    /**
+     * @return void
+     */
     public function setStreetViewControl(?StreetViewControl $streetViewControl = null)
     {
         $this->streetViewControl = $streetViewControl;
@@ -171,7 +181,9 @@ class ControlManager
     {
         return $this->zoomControl;
     }
-
+    /**
+     * @return void
+     */
     public function setZoomControl(?ZoomControl $zoomControl = null)
     {
         $this->zoomControl = $zoomControl;
@@ -195,6 +207,7 @@ class ControlManager
 
     /**
      * @param CustomControl[] $customControls
+     * @return void
      */
     public function setCustomControls(array $customControls)
     {
@@ -204,6 +217,7 @@ class ControlManager
 
     /**
      * @param CustomControl[] $customControls
+     * @return void
      */
     public function addCustomControls(array $customControls)
     {
@@ -219,14 +233,18 @@ class ControlManager
     {
         return in_array($customControl, $this->customControls, true);
     }
-
+    /**
+     * @return void
+     */
     public function addCustomControl(CustomControl $customControl)
     {
         if (!$this->hasCustomControl($customControl)) {
             $this->customControls[] = $customControl;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeCustomControl(CustomControl $customControl)
     {
         unset($this->customControls[array_search($customControl, $this->customControls, true)]);

--- a/src/Control/CustomControl.php
+++ b/src/Control/CustomControl.php
@@ -46,6 +46,7 @@ class CustomControl
 
     /**
      * @param string $position
+     * @return void
      */
     public function setPosition($position)
     {
@@ -62,6 +63,7 @@ class CustomControl
 
     /**
      * @param string $control
+     * @return void
      */
     public function setControl($control)
     {

--- a/src/Control/FullscreenControl.php
+++ b/src/Control/FullscreenControl.php
@@ -39,6 +39,7 @@ class FullscreenControl
 
     /**
      * @param string $position
+     * @return void
      */
     public function setPosition($position)
     {

--- a/src/Control/MapTypeControl.php
+++ b/src/Control/MapTypeControl.php
@@ -68,6 +68,7 @@ class MapTypeControl
 
     /**
      * @param string[] $ids
+     * @return void
      */
     public function setIds(array $ids)
     {
@@ -77,6 +78,7 @@ class MapTypeControl
 
     /**
      * @param string[] $ids
+     * @return void
      */
     public function addIds(array $ids)
     {
@@ -97,6 +99,7 @@ class MapTypeControl
 
     /**
      * @param string $id
+     * @return void
      */
     public function addId($id)
     {
@@ -107,6 +110,7 @@ class MapTypeControl
 
     /**
      * @param string $id
+     * @return void
      */
     public function removeId($id)
     {
@@ -124,6 +128,7 @@ class MapTypeControl
 
     /**
      * @param string $position
+     * @return void
      */
     public function setPosition($position)
     {
@@ -140,6 +145,7 @@ class MapTypeControl
 
     /**
      * @param string $style
+     * @return void
      */
     public function setStyle($style)
     {

--- a/src/Control/RotateControl.php
+++ b/src/Control/RotateControl.php
@@ -41,6 +41,7 @@ class RotateControl
 
     /**
      * @param string $position
+     * @return void
      */
     public function setPosition($position)
     {

--- a/src/Control/ScaleControl.php
+++ b/src/Control/ScaleControl.php
@@ -48,6 +48,7 @@ class ScaleControl
 
     /**
      * @param string $position
+     * @return void
      */
     public function setPosition($position)
     {
@@ -64,6 +65,7 @@ class ScaleControl
 
     /**
      * @param string $style
+     * @return void
      */
     public function setStyle($style)
     {

--- a/src/Control/StreetViewControl.php
+++ b/src/Control/StreetViewControl.php
@@ -41,6 +41,7 @@ class StreetViewControl
 
     /**
      * @param string $position
+     * @return void
      */
     public function setPosition($position)
     {

--- a/src/Control/ZoomControl.php
+++ b/src/Control/ZoomControl.php
@@ -48,6 +48,7 @@ class ZoomControl
 
     /**
      * @param string $position
+     * @return void
      */
     public function setPosition($position)
     {
@@ -64,6 +65,7 @@ class ZoomControl
 
     /**
      * @param string $style
+     * @return void
      */
     public function setStyle($style)
     {

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -67,6 +67,7 @@ class Event implements VariableAwareInterface
 
     /**
      * @param string $instance
+     * @return void
      */
     public function setInstance($instance)
     {
@@ -83,6 +84,7 @@ class Event implements VariableAwareInterface
 
     /**
      * @param string $trigger
+     * @return void
      */
     public function setTrigger($trigger)
     {
@@ -99,6 +101,7 @@ class Event implements VariableAwareInterface
 
     /**
      * @param string $handle
+     * @return void
      */
     public function setHandle($handle)
     {
@@ -115,6 +118,7 @@ class Event implements VariableAwareInterface
 
     /**
      * @param bool $capture
+     * @return void
      */
     public function setCapture($capture)
     {

--- a/src/Event/EventManager.php
+++ b/src/Event/EventManager.php
@@ -56,6 +56,7 @@ class EventManager
 
     /**
      * @param Event[] $domEvents
+     * @return void
      */
     public function setDomEvents(array $domEvents)
     {
@@ -65,6 +66,7 @@ class EventManager
 
     /**
      * @param Event[] $domEvents
+     * @return void
      */
     public function addDomEvents(array $domEvents)
     {
@@ -80,14 +82,18 @@ class EventManager
     {
         return in_array($domEvent, $this->domEvents, true);
     }
-
+    /**
+     * @return void
+     */
     public function addDomEvent(Event $domEvent)
     {
         if (!$this->hasDomEvent($domEvent)) {
             $this->domEvents[] = $domEvent;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeDomEvent(Event $domEvent)
     {
         unset($this->domEvents[array_search($domEvent, $this->domEvents, true)]);
@@ -112,6 +118,7 @@ class EventManager
 
     /**
      * @param Event[] $domEventsOnce
+     * @return void
      */
     public function setDomEventsOnce(array $domEventsOnce)
     {
@@ -121,6 +128,7 @@ class EventManager
 
     /**
      * @param Event[] $domEventsOnce
+     * @return void
      */
     public function addDomEventsOnce(array $domEventsOnce)
     {
@@ -136,14 +144,18 @@ class EventManager
     {
         return in_array($domEventOnce, $this->domEventsOnce, true);
     }
-
+    /**
+     * @return void
+     */
     public function addDomEventOnce(Event $domEventOnce)
     {
         if (!$this->hasDomEventOnce($domEventOnce)) {
             $this->domEventsOnce[] = $domEventOnce;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeDomEventOnce(Event $domEventOnce)
     {
         unset($this->domEventsOnce[array_search($domEventOnce, $this->domEventsOnce, true)]);
@@ -168,6 +180,7 @@ class EventManager
 
     /**
      * @param Event[] $events
+     * @return void
      */
     public function setEvents(array $events)
     {
@@ -177,6 +190,7 @@ class EventManager
 
     /**
      * @param Event[] $events
+     * @return void
      */
     public function addEvents(array $events)
     {
@@ -192,14 +206,18 @@ class EventManager
     {
         return in_array($event, $this->events, true);
     }
-
+    /**
+     * @return void
+     */
     public function addEvent(Event $event)
     {
         if (!$this->hasEvent($event)) {
             $this->events[] = $event;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeEvent(Event $event)
     {
         unset($this->events[array_search($event, $this->events, true)]);
@@ -224,6 +242,7 @@ class EventManager
 
     /**
      * @param Event[] $eventsOnce
+     * @return void
      */
     public function setEventsOnce(array $eventsOnce)
     {
@@ -233,6 +252,7 @@ class EventManager
 
     /**
      * @param Event[] $eventsOnce
+     * @return void
      */
     public function addEventsOnce(array $eventsOnce)
     {
@@ -248,12 +268,16 @@ class EventManager
     {
         return in_array($eventOnce, $this->eventsOnce, true);
     }
-
+    /**
+     * @return void
+     */
     public function addEventOnce(Event $eventOnce)
     {
         $this->eventsOnce[] = $eventOnce;
     }
-
+    /**
+     * @return void
+     */
     public function removeEventOnce(Event $eventOnce)
     {
         unset($this->eventsOnce[array_search($eventOnce, $this->eventsOnce, true)]);

--- a/src/Helper/AbstractHelper.php
+++ b/src/Helper/AbstractHelper.php
@@ -38,6 +38,7 @@ abstract class AbstractHelper
 
     /**
      * @param EventDispatcherInterface $eventDispatcher
+     * @return void
      */
     public function setEventDispatcher(EventDispatcherInterface $eventDispatcher)
     {

--- a/src/Helper/Collector/Base/BoundCollector.php
+++ b/src/Helper/Collector/Base/BoundCollector.php
@@ -45,7 +45,9 @@ class BoundCollector extends AbstractCollector
     {
         return $this->groundOverlayCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setGroundOverlayCollector(GroundOverlayCollector $groundOverlayCollector)
     {
         $this->groundOverlayCollector = $groundOverlayCollector;
@@ -58,7 +60,9 @@ class BoundCollector extends AbstractCollector
     {
         return $this->rectangleCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setRectangleCollector(RectangleCollector $rectangleCollector)
     {
         $this->rectangleCollector = $rectangleCollector;

--- a/src/Helper/Collector/Base/CoordinateCollector.php
+++ b/src/Helper/Collector/Base/CoordinateCollector.php
@@ -86,7 +86,9 @@ class CoordinateCollector extends AbstractCollector
     {
         return $this->boundCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setBoundCollector(BoundCollector $boundCollector)
     {
         $this->boundCollector = $boundCollector;
@@ -99,7 +101,9 @@ class CoordinateCollector extends AbstractCollector
     {
         return $this->circleCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setCircleCollector(CircleCollector $circleCollector)
     {
         $this->circleCollector = $circleCollector;
@@ -112,7 +116,9 @@ class CoordinateCollector extends AbstractCollector
     {
         return $this->infoWindowCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setInfoWindowCollector(InfoWindowCollector $infoWindowCollector)
     {
         $this->infoWindowCollector = $infoWindowCollector;
@@ -125,7 +131,9 @@ class CoordinateCollector extends AbstractCollector
     {
         return $this->markerCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setMarkerCollector(MarkerCollector $markerCollector)
     {
         $this->markerCollector = $markerCollector;
@@ -138,7 +146,9 @@ class CoordinateCollector extends AbstractCollector
     {
         return $this->polygonCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setPolygonCollector(PolygonCollector $polygonCollector)
     {
         $this->polygonCollector = $polygonCollector;
@@ -151,7 +161,9 @@ class CoordinateCollector extends AbstractCollector
     {
         return $this->polylineCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setPolylineCollector(PolylineCollector $polylineCollector)
     {
         $this->polylineCollector = $polylineCollector;
@@ -164,7 +176,9 @@ class CoordinateCollector extends AbstractCollector
     {
         return $this->heatmapLayerCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setHeatmapLayerCollector(HeatmapLayerCollector $heatmapLayerCollector)
     {
         $this->heatmapLayerCollector = $heatmapLayerCollector;

--- a/src/Helper/Collector/Base/PointCollector.php
+++ b/src/Helper/Collector/Base/PointCollector.php
@@ -38,7 +38,9 @@ class PointCollector extends AbstractCollector
     {
         return $this->markerCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setMarkerCollector(MarkerCollector $markerCollector)
     {
         $this->markerCollector = $markerCollector;

--- a/src/Helper/Collector/Base/SizeCollector.php
+++ b/src/Helper/Collector/Base/SizeCollector.php
@@ -45,7 +45,9 @@ class SizeCollector extends AbstractCollector
     {
         return $this->infoWindowCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setInfoWindowCollector(InfoWindowCollector $infoWindowCollector)
     {
         $this->infoWindowCollector = $infoWindowCollector;
@@ -58,7 +60,9 @@ class SizeCollector extends AbstractCollector
     {
         return $this->iconCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setIconCollector(IconCollector $iconCollector)
     {
         $this->iconCollector = $iconCollector;

--- a/src/Helper/Collector/Overlay/IconCollector.php
+++ b/src/Helper/Collector/Overlay/IconCollector.php
@@ -37,7 +37,9 @@ class IconCollector extends AbstractCollector
     {
         return $this->markerCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setMarkerCollector(MarkerCollector $markerCollector)
     {
         $this->markerCollector = $markerCollector;

--- a/src/Helper/Collector/Overlay/IconSequenceCollector.php
+++ b/src/Helper/Collector/Overlay/IconSequenceCollector.php
@@ -37,7 +37,9 @@ class IconSequenceCollector extends AbstractCollector
     {
         return $this->polylineCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setPolylineCollector(PolylineCollector $polylineCollector)
     {
         $this->polylineCollector = $polylineCollector;

--- a/src/Helper/Collector/Overlay/InfoWindowCollector.php
+++ b/src/Helper/Collector/Overlay/InfoWindowCollector.php
@@ -49,7 +49,9 @@ class InfoWindowCollector extends AbstractCollector
     {
         return $this->markerCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setMarkerCollector(MarkerCollector $markerCollector)
     {
         $this->markerCollector = $markerCollector;
@@ -65,6 +67,7 @@ class InfoWindowCollector extends AbstractCollector
 
     /**
      * @param string|null $type
+     * @return void
      */
     public function setType($type)
     {

--- a/src/Helper/Collector/Overlay/MarkerShapeCollector.php
+++ b/src/Helper/Collector/Overlay/MarkerShapeCollector.php
@@ -37,7 +37,9 @@ class MarkerShapeCollector extends AbstractCollector
     {
         return $this->markerCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setMarkerCollector(MarkerCollector $markerCollector)
     {
         $this->markerCollector = $markerCollector;

--- a/src/Helper/Collector/Overlay/SymbolCollector.php
+++ b/src/Helper/Collector/Overlay/SymbolCollector.php
@@ -43,7 +43,9 @@ class SymbolCollector extends AbstractCollector
     {
         return $this->markerCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setMarkerCollector(MarkerCollector $markerCollector)
     {
         $this->markerCollector = $markerCollector;
@@ -56,7 +58,9 @@ class SymbolCollector extends AbstractCollector
     {
         return $this->iconSequenceCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setIconSequenceCollector(IconSequenceCollector $iconSequenceCollector)
     {
         $this->iconSequenceCollector = $iconSequenceCollector;

--- a/src/Helper/Collector/Place/Base/AutocompleteCoordinateCollector.php
+++ b/src/Helper/Collector/Place/Base/AutocompleteCoordinateCollector.php
@@ -37,7 +37,9 @@ class AutocompleteCoordinateCollector extends AbstractCollector
     {
         return $this->boundCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setBoundCollector(AutocompleteBoundCollector $boundCollector)
     {
         $this->boundCollector = $boundCollector;

--- a/src/Helper/Event/AbstractEvent.php
+++ b/src/Helper/Event/AbstractEvent.php
@@ -41,6 +41,7 @@ class AbstractEvent extends Event
 
     /**
      * @param string $code
+     * @return void
      */
     public function setCode($code)
     {
@@ -49,6 +50,7 @@ class AbstractEvent extends Event
 
     /**
      * @param string $code
+     * @return void
      */
     public function addCode($code)
     {

--- a/src/Helper/Event/ApiEvent.php
+++ b/src/Helper/Event/ApiEvent.php
@@ -11,6 +11,9 @@
 
 namespace Ivory\GoogleMap\Helper\Event;
 
+use SplObjectStorage;
+
+
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
@@ -103,6 +106,7 @@ class ApiEvent extends AbstractEvent
 
     /**
      * @param string[] $sources
+     * @return void
      */
     public function setSources(array $sources)
     {
@@ -112,6 +116,7 @@ class ApiEvent extends AbstractEvent
 
     /**
      * @param string[] $sources
+     * @return void
      */
     public function addSources(array $sources)
     {
@@ -132,6 +137,7 @@ class ApiEvent extends AbstractEvent
 
     /**
      * @param string $source
+     * @return void
      */
     public function addSource($source)
     {
@@ -142,6 +148,7 @@ class ApiEvent extends AbstractEvent
 
     /**
      * @param string $source
+     * @return void
      */
     public function removeSource($source)
     {
@@ -167,6 +174,7 @@ class ApiEvent extends AbstractEvent
 
     /**
      * @param string[] $libraries
+     * @return void
      */
     public function setLibraries(array $libraries)
     {
@@ -176,6 +184,7 @@ class ApiEvent extends AbstractEvent
 
     /**
      * @param string[] $libraries
+     * @return void
      */
     public function addLibraries(array $libraries)
     {
@@ -196,6 +205,7 @@ class ApiEvent extends AbstractEvent
 
     /**
      * @param string $library
+     * @return void
      */
     public function addLibrary($library)
     {
@@ -206,6 +216,7 @@ class ApiEvent extends AbstractEvent
 
     /**
      * @param string $library
+     * @return void
      */
     public function removeLibrary($library)
     {
@@ -284,6 +295,7 @@ class ApiEvent extends AbstractEvent
     /**
      * @param object $object
      * @param string $callback
+     * @return void
      */
     public function addCallback($object, $callback)
     {
@@ -294,6 +306,7 @@ class ApiEvent extends AbstractEvent
 
     /**
      * @param object $object
+     * @return void
      */
     public function removeCallbackObject($object)
     {
@@ -302,6 +315,7 @@ class ApiEvent extends AbstractEvent
 
     /**
      * @param string $callback
+     * @return void
      */
     public function removeCallback($callback)
     {
@@ -347,6 +361,7 @@ class ApiEvent extends AbstractEvent
     /**
      * @param object   $object
      * @param string[] $requirements
+     * @return void
      */
     public function setRequirements($object, array $requirements)
     {
@@ -357,6 +372,7 @@ class ApiEvent extends AbstractEvent
     /**
      * @param object   $object
      * @param string[] $requirements
+     * @return void
      */
     public function addRequirements($object, array $requirements)
     {
@@ -380,6 +396,7 @@ class ApiEvent extends AbstractEvent
     /**
      * @param object $object
      * @param string $requirement
+     * @return void
      */
     public function addRequirement($object, $requirement)
     {
@@ -398,6 +415,7 @@ class ApiEvent extends AbstractEvent
     /**
      * @param object      $object
      * @param string|null $requirement
+     * @return void
      */
     public function removeRequirement($object, $requirement = null)
     {

--- a/src/Helper/Event/StaticMapEvent.php
+++ b/src/Helper/Event/StaticMapEvent.php
@@ -64,6 +64,7 @@ class StaticMapEvent extends Event
 
     /**
      * @param mixed[] $parameters
+     * @return void
      */
     public function setParameters(array $parameters)
     {
@@ -73,6 +74,7 @@ class StaticMapEvent extends Event
 
     /**
      * @param mixed[] $parameters
+     * @return void
      */
     public function addParameters(array $parameters)
     {
@@ -104,6 +106,7 @@ class StaticMapEvent extends Event
     /**
      * @param string $parameter
      * @param mixed  $value
+     * @return void
      */
     public function setParameter($parameter, $value)
     {
@@ -112,6 +115,7 @@ class StaticMapEvent extends Event
 
     /**
      * @param string $parameter
+     * @return void
      */
     public function removeParameter($parameter)
     {

--- a/src/Helper/Formatter/Formatter.php
+++ b/src/Helper/Formatter/Formatter.php
@@ -48,6 +48,7 @@ class Formatter
 
     /**
      * @param bool $debug
+     * @return void
      */
     public function setDebug($debug)
     {
@@ -64,6 +65,7 @@ class Formatter
 
     /**
      * @param int $indentationStep
+     * @return void
      */
     public function setIndentationStep($indentationStep)
     {

--- a/src/Helper/Renderer/AbstractJsonRenderer.php
+++ b/src/Helper/Renderer/AbstractJsonRenderer.php
@@ -48,7 +48,9 @@ abstract class AbstractJsonRenderer extends AbstractRenderer
             ->reset()
             ->setJsonEncodeOptions($jsonEncodeOptions);
     }
-
+    /**
+     * @return void
+     */
     public function setJsonBuilder(JsonBuilder $jsonBuilder)
     {
         $this->jsonBuilder = $jsonBuilder;

--- a/src/Helper/Renderer/AbstractRenderer.php
+++ b/src/Helper/Renderer/AbstractRenderer.php
@@ -38,6 +38,7 @@ abstract class AbstractRenderer
 
     /**
      * @param Formatter $formatter
+     * @return void
      */
     public function setFormatter($formatter)
     {

--- a/src/Helper/Renderer/ApiInitRenderer.php
+++ b/src/Helper/Renderer/ApiInitRenderer.php
@@ -11,6 +11,9 @@
 
 namespace Ivory\GoogleMap\Helper\Renderer;
 
+use SplObjectStorage;
+
+
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */

--- a/src/Helper/Renderer/ApiRenderer.php
+++ b/src/Helper/Renderer/ApiRenderer.php
@@ -14,6 +14,7 @@ namespace Ivory\GoogleMap\Helper\Renderer;
 use Ivory\GoogleMap\Helper\Formatter\Formatter;
 use Ivory\GoogleMap\Helper\Renderer\Utility\RequirementLoaderRenderer;
 use Ivory\GoogleMap\Helper\Renderer\Utility\SourceRenderer;
+use SplObjectStorage;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -62,7 +63,9 @@ class ApiRenderer extends AbstractRenderer
     {
         return $this->apiInitRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setApiInitRenderer(ApiInitRenderer $apiInitRenderer)
     {
         $this->apiInitRenderer = $apiInitRenderer;
@@ -75,7 +78,9 @@ class ApiRenderer extends AbstractRenderer
     {
         return $this->loaderRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setLoaderRenderer(LoaderRenderer $loaderRenderer)
     {
         $this->loaderRenderer = $loaderRenderer;
@@ -88,7 +93,9 @@ class ApiRenderer extends AbstractRenderer
     {
         return $this->requirementLoaderRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setRequirementLoaderRenderer(RequirementLoaderRenderer $requirementLoaderRenderer)
     {
         $this->requirementLoaderRenderer = $requirementLoaderRenderer;
@@ -101,7 +108,9 @@ class ApiRenderer extends AbstractRenderer
     {
         return $this->sourceRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setSourceRenderer(SourceRenderer $sourceRenderer)
     {
         $this->sourceRenderer = $sourceRenderer;

--- a/src/Helper/Renderer/Control/ControlManagerRenderer.php
+++ b/src/Helper/Renderer/Control/ControlManagerRenderer.php
@@ -42,6 +42,7 @@ class ControlManagerRenderer
 
     /**
      * @param ControlRendererInterface[] $renderers
+     * @return void
      */
     public function setRenderers(array $renderers)
     {
@@ -51,6 +52,7 @@ class ControlManagerRenderer
 
     /**
      * @param ControlRendererInterface[] $renderers
+     * @return void
      */
     public function addRenderers(array $renderers)
     {
@@ -66,14 +68,18 @@ class ControlManagerRenderer
     {
         return in_array($renderer, $this->renderers, true);
     }
-
+    /**
+     * @return void
+     */
     public function addRenderer(ControlRendererInterface $renderer)
     {
         if (!$this->hasRenderer($renderer)) {
             $this->renderers[] = $renderer;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeRenderer(ControlRendererInterface $renderer)
     {
         unset($this->renderers[array_search($renderer, $this->renderers, true)]);

--- a/src/Helper/Renderer/Control/CustomControlRenderer.php
+++ b/src/Helper/Renderer/Control/CustomControlRenderer.php
@@ -40,7 +40,9 @@ class CustomControlRenderer extends AbstractRenderer
     {
         return $this->controlPositionRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setControlPositionRenderer(ControlPositionRenderer $controlPositionRenderer)
     {
         $this->controlPositionRenderer = $controlPositionRenderer;

--- a/src/Helper/Renderer/Control/FullscreenControlRenderer.php
+++ b/src/Helper/Renderer/Control/FullscreenControlRenderer.php
@@ -43,7 +43,9 @@ class FullscreenControlRenderer extends AbstractJsonRenderer implements ControlR
     {
         return $this->controlPositionRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setControlPositionRenderer(ControlPositionRenderer $controlPositionRenderer)
     {
         $this->controlPositionRenderer = $controlPositionRenderer;

--- a/src/Helper/Renderer/Control/MapTypeControlRenderer.php
+++ b/src/Helper/Renderer/Control/MapTypeControlRenderer.php
@@ -58,7 +58,9 @@ class MapTypeControlRenderer extends AbstractJsonRenderer implements ControlRend
     {
         return $this->mapTypeIdRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setMapTypeIdRenderer(MapTypeIdRenderer $mapTypeIdRenderer)
     {
         $this->mapTypeIdRenderer = $mapTypeIdRenderer;
@@ -71,7 +73,9 @@ class MapTypeControlRenderer extends AbstractJsonRenderer implements ControlRend
     {
         return $this->controlPositionRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setControlPositionRenderer(ControlPositionRenderer $controlPositionRenderer)
     {
         $this->controlPositionRenderer = $controlPositionRenderer;
@@ -84,7 +88,9 @@ class MapTypeControlRenderer extends AbstractJsonRenderer implements ControlRend
     {
         return $this->mapTypeControlStyleRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setMapTypeControlStyleRenderer(MapTypeControlStyleRenderer $mapTypeControlStyleRenderer)
     {
         $this->mapTypeControlStyleRenderer = $mapTypeControlStyleRenderer;

--- a/src/Helper/Renderer/Control/RotateControlRenderer.php
+++ b/src/Helper/Renderer/Control/RotateControlRenderer.php
@@ -43,7 +43,9 @@ class RotateControlRenderer extends AbstractJsonRenderer implements ControlRende
     {
         return $this->controlPositionRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setControlPositionRenderer(ControlPositionRenderer $controlPositionRenderer)
     {
         $this->controlPositionRenderer = $controlPositionRenderer;

--- a/src/Helper/Renderer/Control/ScaleControlRenderer.php
+++ b/src/Helper/Renderer/Control/ScaleControlRenderer.php
@@ -50,7 +50,9 @@ class ScaleControlRenderer extends AbstractJsonRenderer implements ControlRender
     {
         return $this->controlPositionRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setControlPositionRenderer(ControlPositionRenderer $controlPositionRenderer)
     {
         $this->controlPositionRenderer = $controlPositionRenderer;
@@ -63,7 +65,9 @@ class ScaleControlRenderer extends AbstractJsonRenderer implements ControlRender
     {
         return $this->scaleControlStyleRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setScaleControlStyleRenderer(ScaleControlStyleRenderer $scaleControlStyleRenderer)
     {
         $this->scaleControlStyleRenderer = $scaleControlStyleRenderer;

--- a/src/Helper/Renderer/Control/StreetViewControlRenderer.php
+++ b/src/Helper/Renderer/Control/StreetViewControlRenderer.php
@@ -43,7 +43,9 @@ class StreetViewControlRenderer extends AbstractJsonRenderer implements ControlR
     {
         return $this->controlPositionRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setControlPositionRenderer(ControlPositionRenderer $controlPositionRenderer)
     {
         $this->controlPositionRenderer = $controlPositionRenderer;

--- a/src/Helper/Renderer/Control/ZoomControlRenderer.php
+++ b/src/Helper/Renderer/Control/ZoomControlRenderer.php
@@ -50,7 +50,9 @@ class ZoomControlRenderer extends AbstractJsonRenderer implements ControlRendere
     {
         return $this->controlPositionRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setControlPositionRenderer(ControlPositionRenderer $controlPositionRenderer)
     {
         $this->controlPositionRenderer = $controlPositionRenderer;
@@ -63,7 +65,9 @@ class ZoomControlRenderer extends AbstractJsonRenderer implements ControlRendere
     {
         return $this->zoomControlStyleRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setZoomControlStyleRenderer(ZoomControlStyleRenderer $zoomControlStyleRenderer)
     {
         $this->zoomControlStyleRenderer = $zoomControlStyleRenderer;

--- a/src/Helper/Renderer/Html/AbstractTagRenderer.php
+++ b/src/Helper/Renderer/Html/AbstractTagRenderer.php
@@ -38,7 +38,9 @@ class AbstractTagRenderer extends AbstractRenderer
     {
         return $this->tagRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setTagRenderer(TagRenderer $tagRenderer)
     {
         $this->tagRenderer = $tagRenderer;

--- a/src/Helper/Renderer/Html/StylesheetTagRenderer.php
+++ b/src/Helper/Renderer/Html/StylesheetTagRenderer.php
@@ -37,7 +37,9 @@ class StylesheetTagRenderer extends AbstractTagRenderer
     {
         return $this->stylesheetRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setStylesheetRenderer(StylesheetRenderer $stylesheetRenderer)
     {
         $this->stylesheetRenderer = $stylesheetRenderer;

--- a/src/Helper/Renderer/LoaderRenderer.php
+++ b/src/Helper/Renderer/LoaderRenderer.php
@@ -51,6 +51,7 @@ class LoaderRenderer extends AbstractJsonRenderer
 
     /**
      * @param string $language
+     * @return void
      */
     public function setLanguage($language)
     {
@@ -75,6 +76,7 @@ class LoaderRenderer extends AbstractJsonRenderer
 
     /**
      * @param string|null $key
+     * @return void
      */
     public function setKey($key)
     {

--- a/src/Helper/Renderer/MapHtmlRenderer.php
+++ b/src/Helper/Renderer/MapHtmlRenderer.php
@@ -41,7 +41,9 @@ class MapHtmlRenderer extends AbstractTagRenderer
     {
         return $this->stylesheetRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setStylesheetRenderer(StylesheetRenderer $stylesheetRenderer)
     {
         $this->stylesheetRenderer = $stylesheetRenderer;

--- a/src/Helper/Renderer/MapRenderer.php
+++ b/src/Helper/Renderer/MapRenderer.php
@@ -59,7 +59,9 @@ class MapRenderer extends AbstractJsonRenderer
     {
         return $this->mapTypeIdRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setMapTypeIdRenderer(MapTypeIdRenderer $mapTypeIdRenderer)
     {
         $this->mapTypeIdRenderer = $mapTypeIdRenderer;
@@ -72,7 +74,9 @@ class MapRenderer extends AbstractJsonRenderer
     {
         return $this->controlManagerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setControlManagerRenderer(ControlManagerRenderer $controlManagerRenderer)
     {
         $this->controlManagerRenderer = $controlManagerRenderer;
@@ -88,6 +92,7 @@ class MapRenderer extends AbstractJsonRenderer
 
     /**
      * @param RequirementRenderer $requirementRenderer
+     * @return void
      */
     public function setRequirementRenderer($requirementRenderer)
     {

--- a/src/Helper/Renderer/Overlay/EncodedPolylineRenderer.php
+++ b/src/Helper/Renderer/Overlay/EncodedPolylineRenderer.php
@@ -45,7 +45,9 @@ class EncodedPolylineRenderer extends AbstractJsonRenderer
     {
         return $this->encodingRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setEncodingRenderer(EncodingRenderer $encodingRenderer)
     {
         $this->encodingRenderer = $encodingRenderer;

--- a/src/Helper/Renderer/Overlay/Extendable/ExtendableRenderer.php
+++ b/src/Helper/Renderer/Overlay/Extendable/ExtendableRenderer.php
@@ -42,6 +42,7 @@ class ExtendableRenderer implements ExtendableRendererInterface
 
     /**
      * @param ExtendableRendererInterface[] $renderers
+     * @return void
      */
     public function setRenderers(array $renderers)
     {
@@ -51,6 +52,7 @@ class ExtendableRenderer implements ExtendableRendererInterface
 
     /**
      * @param ExtendableRendererInterface[] $renderers
+     * @return void
      */
     public function addRenderers(array $renderers)
     {
@@ -81,6 +83,7 @@ class ExtendableRenderer implements ExtendableRendererInterface
 
     /**
      * @param string $name
+     * @return void
      */
     public function setRenderer($name, ExtendableRendererInterface $renderer)
     {
@@ -89,6 +92,7 @@ class ExtendableRenderer implements ExtendableRendererInterface
 
     /**
      * @param string $name
+     * @return void
      */
     public function removeRenderer($name)
     {

--- a/src/Helper/Renderer/Overlay/InfoBoxRenderer.php
+++ b/src/Helper/Renderer/Overlay/InfoBoxRenderer.php
@@ -42,7 +42,9 @@ class InfoBoxRenderer extends AbstractInfoWindowRenderer
     {
         return $this->requirementRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setRequirementRenderer(RequirementRenderer $requirementRenderer)
     {
         $this->requirementRenderer = $requirementRenderer;

--- a/src/Helper/Renderer/Overlay/MarkerClustererRenderer.php
+++ b/src/Helper/Renderer/Overlay/MarkerClustererRenderer.php
@@ -45,7 +45,9 @@ class MarkerClustererRenderer extends AbstractJsonRenderer
     {
         return $this->requirementRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setRequirementRenderer(RequirementRenderer $requirementRenderer)
     {
         $this->requirementRenderer = $requirementRenderer;

--- a/src/Helper/Renderer/Overlay/MarkerRenderer.php
+++ b/src/Helper/Renderer/Overlay/MarkerRenderer.php
@@ -44,7 +44,9 @@ class MarkerRenderer extends AbstractJsonRenderer
     {
         return $this->animationRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setAnimationRenderer(AnimationRenderer $animationRenderer)
     {
         $this->animationRenderer = $animationRenderer;

--- a/src/Helper/Renderer/Overlay/SymbolRenderer.php
+++ b/src/Helper/Renderer/Overlay/SymbolRenderer.php
@@ -40,7 +40,9 @@ class SymbolRenderer extends AbstractJsonRenderer
     {
         return $this->symbolPathRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setSymbolPathRenderer(SymbolPathRenderer $symbolPathRenderer)
     {
         $this->symbolPathRenderer = $symbolPathRenderer;

--- a/src/Helper/Renderer/Place/AutocompleteRenderer.php
+++ b/src/Helper/Renderer/Place/AutocompleteRenderer.php
@@ -44,7 +44,9 @@ class AutocompleteRenderer extends AbstractJsonRenderer
     {
         return $this->requirementRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setRequirementRenderer(RequirementRenderer $requirementRenderer)
     {
         $this->requirementRenderer = $requirementRenderer;

--- a/src/Helper/StaticMapHelper.php
+++ b/src/Helper/StaticMapHelper.php
@@ -73,6 +73,7 @@ class StaticMapHelper extends AbstractHelper
 
     /**
      * @param string|null $secret
+     * @return void
      */
     public function setSecret($secret)
     {
@@ -97,6 +98,7 @@ class StaticMapHelper extends AbstractHelper
 
     /**
      * @param string|null $clientId
+     * @return void
      */
     public function setClientId($clientId)
     {
@@ -121,6 +123,7 @@ class StaticMapHelper extends AbstractHelper
 
     /**
      * @param string|null $channel
+     * @return void
      */
     public function setChannel($channel)
     {

--- a/src/Helper/Subscriber/AbstractDelegateSubscriber.php
+++ b/src/Helper/Subscriber/AbstractDelegateSubscriber.php
@@ -21,6 +21,7 @@ abstract class AbstractDelegateSubscriber extends AbstractSubscriber implements 
 {
     /**
      * @param string $eventName
+     * @return void
      */
     public function handle(Event $event, $eventName, EventDispatcherInterface $eventDispatcher)
     {
@@ -35,6 +36,7 @@ abstract class AbstractDelegateSubscriber extends AbstractSubscriber implements 
 
     /**
      * {@inheritdoc}
+     * @return array<<missing>,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/AbstractSubscriber.php
+++ b/src/Helper/Subscriber/AbstractSubscriber.php
@@ -36,7 +36,9 @@ abstract class AbstractSubscriber implements EventSubscriberInterface
     {
         return $this->formatter;
     }
-
+    /**
+     * @return void
+     */
     public function setFormatter(Formatter $formatter)
     {
         $this->formatter = $formatter;

--- a/src/Helper/Subscriber/ApiJavascriptSubscriber.php
+++ b/src/Helper/Subscriber/ApiJavascriptSubscriber.php
@@ -52,7 +52,9 @@ class ApiJavascriptSubscriber extends AbstractDelegateSubscriber
     {
         return $this->apiRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setApiRenderer(ApiRenderer $apiRenderer)
     {
         $this->apiRenderer = $apiRenderer;
@@ -65,7 +67,9 @@ class ApiJavascriptSubscriber extends AbstractDelegateSubscriber
     {
         return $this->javascriptTagRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setJavascriptTagRenderer(JavascriptTagRenderer $javascriptTagRenderer)
     {
         $this->javascriptTagRenderer = $javascriptTagRenderer;
@@ -95,7 +99,9 @@ class ApiJavascriptSubscriber extends AbstractDelegateSubscriber
             ],
         ];
     }
-
+    /**
+     * @return void
+     */
     private function handleApi(ApiEvent $event)
     {
         $event->setCode($this->getJavascriptTagRenderer()->render($this->getApiRenderer()->render(

--- a/src/Helper/Subscriber/Base/BoundSubscriber.php
+++ b/src/Helper/Subscriber/Base/BoundSubscriber.php
@@ -51,7 +51,9 @@ class BoundSubscriber extends AbstractSubscriber
     {
         return $this->boundCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setBoundCollector(BoundCollector $boundCollector)
     {
         $this->boundCollector = $boundCollector;
@@ -64,12 +66,16 @@ class BoundSubscriber extends AbstractSubscriber
     {
         return $this->boundRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setBoundRenderer(BoundRenderer $boundRenderer)
     {
         $this->boundRenderer = $boundRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class BoundSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Base/CoordinateSubscriber.php
+++ b/src/Helper/Subscriber/Base/CoordinateSubscriber.php
@@ -51,7 +51,9 @@ class CoordinateSubscriber extends AbstractSubscriber
     {
         return $this->coordinateCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setCoordinateCollector(CoordinateCollector $coordinateCollector)
     {
         $this->coordinateCollector = $coordinateCollector;
@@ -64,12 +66,16 @@ class CoordinateSubscriber extends AbstractSubscriber
     {
         return $this->coordinateRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setCoordinateRenderer(CoordinateRenderer $coordinateRenderer)
     {
         $this->coordinateRenderer = $coordinateRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class CoordinateSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Base/PointSubscriber.php
+++ b/src/Helper/Subscriber/Base/PointSubscriber.php
@@ -51,7 +51,9 @@ class PointSubscriber extends AbstractSubscriber
     {
         return $this->pointCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setPointCollector(PointCollector $pointCollector)
     {
         $this->pointCollector = $pointCollector;
@@ -64,7 +66,9 @@ class PointSubscriber extends AbstractSubscriber
     {
         return $this->pointRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setPointRenderer(PointRenderer $pointRenderer)
     {
         $this->pointRenderer = $pointRenderer;
@@ -72,6 +76,7 @@ class PointSubscriber extends AbstractSubscriber
 
     /***
      * @param MapEvent $event
+     * @return void
      */
     public function handleMap(MapEvent $event)
     {
@@ -90,6 +95,7 @@ class PointSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Base/SizeSubscriber.php
+++ b/src/Helper/Subscriber/Base/SizeSubscriber.php
@@ -51,7 +51,9 @@ class SizeSubscriber extends AbstractSubscriber
     {
         return $this->sizeCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setSizeCollector(SizeCollector $sizeCollector)
     {
         $this->sizeCollector = $sizeCollector;
@@ -64,12 +66,16 @@ class SizeSubscriber extends AbstractSubscriber
     {
         return $this->sizeRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setSizeRenderer(SizeRenderer $sizeRenderer)
     {
         $this->sizeRenderer = $sizeRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class SizeSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Control/CustomControlSubscriber.php
+++ b/src/Helper/Subscriber/Control/CustomControlSubscriber.php
@@ -51,7 +51,9 @@ class CustomControlSubscriber extends AbstractSubscriber
     {
         return $this->customControlCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setCustomControlCollector(CustomControlCollector $customControlCollector)
     {
         $this->customControlCollector = $customControlCollector;
@@ -64,12 +66,16 @@ class CustomControlSubscriber extends AbstractSubscriber
     {
         return $this->customControlRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setCustomControlRenderer(CustomControlRenderer $customControlRenderer)
     {
         $this->customControlRenderer = $customControlRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -82,6 +88,7 @@ class CustomControlSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Event/DomEventOnceSubscriber.php
+++ b/src/Helper/Subscriber/Event/DomEventOnceSubscriber.php
@@ -51,7 +51,9 @@ class DomEventOnceSubscriber extends AbstractSubscriber
     {
         return $this->domEventOnceCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setDomEventOnceCollector(DomEventOnceCollector $domEventOnceCollector)
     {
         $this->domEventOnceCollector = $domEventOnceCollector;
@@ -64,12 +66,16 @@ class DomEventOnceSubscriber extends AbstractSubscriber
     {
         return $this->domEventOnceRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setDomEventOnceRenderer(DomEventOnceRenderer $domEventOnceRenderer)
     {
         $this->domEventOnceRenderer = $domEventOnceRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class DomEventOnceSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Event/DomEventSubscriber.php
+++ b/src/Helper/Subscriber/Event/DomEventSubscriber.php
@@ -51,7 +51,9 @@ class DomEventSubscriber extends AbstractSubscriber
     {
         return $this->domEventCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setDomEventCollector(DomEventCollector $domEventCollector)
     {
         $this->domEventCollector = $domEventCollector;
@@ -64,12 +66,16 @@ class DomEventSubscriber extends AbstractSubscriber
     {
         return $this->domEventRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setDomEventRenderer(DomEventRenderer $domEventRenderer)
     {
         $this->domEventRenderer = $domEventRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class DomEventSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Event/EventOnceSubscriber.php
+++ b/src/Helper/Subscriber/Event/EventOnceSubscriber.php
@@ -51,7 +51,9 @@ class EventOnceSubscriber extends AbstractSubscriber
     {
         return $this->eventOnceCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setEventOnceCollector(EventOnceCollector $eventOnceCollector)
     {
         $this->eventOnceCollector = $eventOnceCollector;
@@ -64,12 +66,16 @@ class EventOnceSubscriber extends AbstractSubscriber
     {
         return $this->eventOnceRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setEventOnceRenderer(EventOnceRenderer $eventOnceRenderer)
     {
         $this->eventOnceRenderer = $eventOnceRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class EventOnceSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Event/SimpleEventSubscriber.php
+++ b/src/Helper/Subscriber/Event/SimpleEventSubscriber.php
@@ -51,7 +51,9 @@ class SimpleEventSubscriber extends AbstractSubscriber
     {
         return $this->eventCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setEventCollector(EventCollector $eventCollector)
     {
         $this->eventCollector = $eventCollector;
@@ -64,12 +66,16 @@ class SimpleEventSubscriber extends AbstractSubscriber
     {
         return $this->eventRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setEventRenderer(EventRenderer $eventRenderer)
     {
         $this->eventRenderer = $eventRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class SimpleEventSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Image/CenterSubscriber.php
+++ b/src/Helper/Subscriber/Image/CenterSubscriber.php
@@ -31,7 +31,9 @@ class CenterSubscriber implements EventSubscriberInterface
     {
         $this->coordinateRenderer = $coordinateRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(StaticMapEvent $event)
     {
         $map = $event->getMap();
@@ -53,6 +55,7 @@ class CenterSubscriber implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Image/EncodedPolylineSubscriber.php
+++ b/src/Helper/Subscriber/Image/EncodedPolylineSubscriber.php
@@ -39,7 +39,9 @@ class EncodedPolylineSubscriber implements EventSubscriberInterface
         $this->encodedPolylineCollector = $encodedPolylineCollector;
         $this->encodedPolylineRenderer = $encodedPolylineRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(StaticMapEvent $event)
     {
         foreach ($this->encodedPolylineCollector->collect($event->getMap()) as $encodedPolylines) {
@@ -49,6 +51,7 @@ class EncodedPolylineSubscriber implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Image/ExtendableSubscriber.php
+++ b/src/Helper/Subscriber/Image/ExtendableSubscriber.php
@@ -37,7 +37,9 @@ class ExtendableSubscriber implements EventSubscriberInterface
         $this->extendableCollector = $extendableCollector;
         $this->extendableRenderer = $extendableRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(StaticMapEvent $event)
     {
         $map = $event->getMap();
@@ -61,6 +63,7 @@ class ExtendableSubscriber implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Image/FormatSubscriber.php
+++ b/src/Helper/Subscriber/Image/FormatSubscriber.php
@@ -20,6 +20,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class FormatSubscriber implements EventSubscriberInterface
 {
+    /**
+     * @return void
+     */
     public function handleMap(StaticMapEvent $event)
     {
         $map = $event->getMap();
@@ -31,6 +34,7 @@ class FormatSubscriber implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Image/KeySubscriber.php
+++ b/src/Helper/Subscriber/Image/KeySubscriber.php
@@ -32,7 +32,9 @@ class KeySubscriber implements EventSubscriberInterface
     {
         $this->key = $key;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(StaticMapEvent $event)
     {
         if (null !== $this->key) {
@@ -42,6 +44,7 @@ class KeySubscriber implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Image/MarkerSubscriber.php
+++ b/src/Helper/Subscriber/Image/MarkerSubscriber.php
@@ -37,7 +37,9 @@ class MarkerSubscriber implements EventSubscriberInterface
         $this->markerCollector = $markerCollector;
         $this->markerRenderer = $markerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(StaticMapEvent $event)
     {
         $result = [];
@@ -53,6 +55,7 @@ class MarkerSubscriber implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Image/PolylineSubscriber.php
+++ b/src/Helper/Subscriber/Image/PolylineSubscriber.php
@@ -37,7 +37,9 @@ class PolylineSubscriber implements EventSubscriberInterface
         $this->polylineCollector = $polylineCollector;
         $this->polylineRenderer = $polylineRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(StaticMapEvent $event)
     {
         $result = [];
@@ -53,6 +55,7 @@ class PolylineSubscriber implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Image/ScaleSubscriber.php
+++ b/src/Helper/Subscriber/Image/ScaleSubscriber.php
@@ -20,6 +20,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class ScaleSubscriber implements EventSubscriberInterface
 {
+    /**
+     * @return void
+     */
     public function handleMap(StaticMapEvent $event)
     {
         $map = $event->getMap();
@@ -31,6 +34,7 @@ class ScaleSubscriber implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Image/SizeSubscriber.php
+++ b/src/Helper/Subscriber/Image/SizeSubscriber.php
@@ -30,7 +30,9 @@ class SizeSubscriber implements EventSubscriberInterface
     {
         $this->sizeRenderer = $sizeRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(StaticMapEvent $event)
     {
         $event->setParameter('size', $this->sizeRenderer->render($event->getMap()));
@@ -38,6 +40,7 @@ class SizeSubscriber implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Image/StaticSubscriber.php
+++ b/src/Helper/Subscriber/Image/StaticSubscriber.php
@@ -23,6 +23,7 @@ class StaticSubscriber implements DelegateSubscriberInterface
 {
     /**
      * @param string $eventName
+     * @return void
      */
     public function handle(Event $event, $eventName, EventDispatcherInterface $eventDispatcher)
     {
@@ -37,6 +38,7 @@ class StaticSubscriber implements DelegateSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array<<missing>,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Image/StyleSubscriber.php
+++ b/src/Helper/Subscriber/Image/StyleSubscriber.php
@@ -30,7 +30,9 @@ class StyleSubscriber implements EventSubscriberInterface
     {
         $this->styleRenderer = $styleRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(StaticMapEvent $event)
     {
         $map = $event->getMap();
@@ -52,6 +54,7 @@ class StyleSubscriber implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Image/TypeSubscriber.php
+++ b/src/Helper/Subscriber/Image/TypeSubscriber.php
@@ -20,6 +20,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class TypeSubscriber implements EventSubscriberInterface
 {
+    /**
+     * @return void
+     */
     public function handleMap(StaticMapEvent $event)
     {
         $map = $event->getMap();
@@ -37,6 +40,7 @@ class TypeSubscriber implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Image/ZoomSubscriber.php
+++ b/src/Helper/Subscriber/Image/ZoomSubscriber.php
@@ -20,6 +20,9 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class ZoomSubscriber implements EventSubscriberInterface
 {
+    /**
+     * @return void
+     */
     public function handleMap(StaticMapEvent $event)
     {
         $map = $event->getMap();
@@ -37,6 +40,7 @@ class ZoomSubscriber implements EventSubscriberInterface
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Layer/GeoJsonLayerSubscriber.php
+++ b/src/Helper/Subscriber/Layer/GeoJsonLayerSubscriber.php
@@ -51,7 +51,9 @@ class GeoJsonLayerSubscriber extends AbstractSubscriber
     {
         return $this->geoJsonLayerCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setGeoJsonLayerCollector(GeoJsonLayerCollector $geoJsonLayerCollector)
     {
         $this->geoJsonLayerCollector = $geoJsonLayerCollector;
@@ -64,12 +66,16 @@ class GeoJsonLayerSubscriber extends AbstractSubscriber
     {
         return $this->geoJsonLayerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setGeoJsonLayerRenderer(GeoJsonLayerRenderer $geoJsonLayerRenderer)
     {
         $this->geoJsonLayerRenderer = $geoJsonLayerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -82,6 +88,7 @@ class GeoJsonLayerSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Layer/HeatmapLayerSubscriber.php
+++ b/src/Helper/Subscriber/Layer/HeatmapLayerSubscriber.php
@@ -54,7 +54,9 @@ class HeatmapLayerSubscriber extends AbstractSubscriber
     {
         return $this->heatmapLayerCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setHeatmapLayerCollector(HeatmapLayerCollector $heatmapLayerCollector)
     {
         $this->heatmapLayerCollector = $heatmapLayerCollector;
@@ -67,12 +69,16 @@ class HeatmapLayerSubscriber extends AbstractSubscriber
     {
         return $this->heatmapLayerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setHeatmapLayerRenderer(HeatmapLayerRenderer $heatmapLayerRenderer)
     {
         $this->heatmapLayerRenderer = $heatmapLayerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleApi(ApiEvent $event)
     {
         foreach ($event->getObjects(Map::class) as $map) {
@@ -85,7 +91,9 @@ class HeatmapLayerSubscriber extends AbstractSubscriber
             }
         }
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -103,6 +111,7 @@ class HeatmapLayerSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Layer/KmlLayerSubscriber.php
+++ b/src/Helper/Subscriber/Layer/KmlLayerSubscriber.php
@@ -51,7 +51,9 @@ class KmlLayerSubscriber extends AbstractSubscriber
     {
         return $this->kmlLayerCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setKmlLayerCollector(KmlLayerCollector $kmlLayerCollector)
     {
         $this->kmlLayerCollector = $kmlLayerCollector;
@@ -64,12 +66,16 @@ class KmlLayerSubscriber extends AbstractSubscriber
     {
         return $this->kmlLayerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setKmlLayerRenderer(KmlLayerRenderer $kmlLayerRenderer)
     {
         $this->kmlLayerRenderer = $kmlLayerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class KmlLayerSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/MapBoundSubscriber.php
+++ b/src/Helper/Subscriber/MapBoundSubscriber.php
@@ -40,12 +40,16 @@ class MapBoundSubscriber extends AbstractSubscriber
     {
         return $this->mapBoundRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setMapBoundRenderer(MapBoundRenderer $mapBoundRenderer)
     {
         $this->mapBoundRenderer = $mapBoundRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $map = $event->getMap();
@@ -57,6 +61,7 @@ class MapBoundSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/MapCenterSubscriber.php
+++ b/src/Helper/Subscriber/MapCenterSubscriber.php
@@ -40,12 +40,16 @@ class MapCenterSubscriber extends AbstractSubscriber
     {
         return $this->mapCenterRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setMapCenterRenderer(MapCenterRenderer $mapCenterRenderer)
     {
         $this->mapCenterRenderer = $mapCenterRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $map = $event->getMap();
@@ -57,6 +61,7 @@ class MapCenterSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/MapContainerSubscriber.php
+++ b/src/Helper/Subscriber/MapContainerSubscriber.php
@@ -40,12 +40,16 @@ class MapContainerSubscriber extends AbstractSubscriber
     {
         return $this->containerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setContainerRenderer(MapContainerRenderer $containerRenderer)
     {
         $this->containerRenderer = $containerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -59,6 +63,7 @@ class MapContainerSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/MapHtmlSubscriber.php
+++ b/src/Helper/Subscriber/MapHtmlSubscriber.php
@@ -40,12 +40,16 @@ class MapHtmlSubscriber extends AbstractSubscriber
     {
         return $this->mapHtmlRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setMapHtmlRenderer(MapHtmlRenderer $mapHtmlRenderer)
     {
         $this->mapHtmlRenderer = $mapHtmlRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $event->addCode($this->mapHtmlRenderer->render($event->getMap()));
@@ -53,6 +57,7 @@ class MapHtmlSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/MapJavascriptSubscriber.php
+++ b/src/Helper/Subscriber/MapJavascriptSubscriber.php
@@ -63,7 +63,9 @@ class MapJavascriptSubscriber extends AbstractDelegateSubscriber
     {
         return $this->mapRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setMapRenderer(MapRenderer $mapRenderer)
     {
         $this->mapRenderer = $mapRenderer;
@@ -76,7 +78,9 @@ class MapJavascriptSubscriber extends AbstractDelegateSubscriber
     {
         return $this->callbackRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setCallbackRenderer(CallbackRenderer $callbackRenderer)
     {
         $this->callbackRenderer = $callbackRenderer;
@@ -89,7 +93,9 @@ class MapJavascriptSubscriber extends AbstractDelegateSubscriber
     {
         return $this->javascriptTagRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setJavascriptTagRenderer(JavascriptTagRenderer $javascriptTagRenderer)
     {
         $this->javascriptTagRenderer = $javascriptTagRenderer;
@@ -128,7 +134,9 @@ class MapJavascriptSubscriber extends AbstractDelegateSubscriber
             ],
         ];
     }
-
+    /**
+     * @return void
+     */
     private function handleApi(ApiEvent $event)
     {
         foreach ($event->getObjects(Map::class) as $map) {
@@ -137,7 +145,9 @@ class MapJavascriptSubscriber extends AbstractDelegateSubscriber
             $event->addRequirement($map, $this->mapRenderer->renderRequirement());
         }
     }
-
+    /**
+     * @return void
+     */
     private function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();

--- a/src/Helper/Subscriber/MapStylesheetSubscriber.php
+++ b/src/Helper/Subscriber/MapStylesheetSubscriber.php
@@ -40,12 +40,16 @@ class MapStylesheetSubscriber extends AbstractSubscriber
     {
         return $this->stylesheetTagRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setStylesheetTagRenderer(StylesheetTagRenderer $stylesheetTagRenderer)
     {
         $this->stylesheetTagRenderer = $stylesheetTagRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $map = $event->getMap();
@@ -57,6 +61,7 @@ class MapStylesheetSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/MapSubscriber.php
+++ b/src/Helper/Subscriber/MapSubscriber.php
@@ -40,12 +40,16 @@ class MapSubscriber extends AbstractSubscriber
     {
         return $this->mapRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setMapRenderer(MapRenderer $mapRenderer)
     {
         $this->mapRenderer = $mapRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $map = $event->getMap();
@@ -59,6 +63,7 @@ class MapSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/AbstractInfoWindowSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/AbstractInfoWindowSubscriber.php
@@ -39,7 +39,9 @@ abstract class AbstractInfoWindowSubscriber extends AbstractSubscriber
     {
         return $this->infoWindowCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setInfoWindowCollector(InfoWindowCollector $infoWindowCollector)
     {
         $this->infoWindowCollector = $infoWindowCollector;

--- a/src/Helper/Subscriber/Overlay/AbstractMarkerSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/AbstractMarkerSubscriber.php
@@ -41,7 +41,9 @@ abstract class AbstractMarkerSubscriber extends AbstractSubscriber
     {
         return $this->markerCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setMarkerCollector(MarkerCollector $markerCollector)
     {
         $this->markerCollector = $markerCollector;

--- a/src/Helper/Subscriber/Overlay/CircleSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/CircleSubscriber.php
@@ -51,7 +51,9 @@ class CircleSubscriber extends AbstractSubscriber
     {
         return $this->circleCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setCircleCollector(CircleCollector $circleCollector)
     {
         $this->circleCollector = $circleCollector;
@@ -64,12 +66,16 @@ class CircleSubscriber extends AbstractSubscriber
     {
         return $this->circleRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setCircleRenderer(CircleRenderer $circleRenderer)
     {
         $this->circleRenderer = $circleRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class CircleSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/DefaultInfoWindowSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/DefaultInfoWindowSubscriber.php
@@ -47,12 +47,16 @@ class DefaultInfoWindowSubscriber extends AbstractInfoWindowSubscriber
     {
         return $this->infoWindowRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setInfoWindowRenderer(DefaultInfoWindowRenderer $infoWindowRenderer)
     {
         $this->infoWindowRenderer = $infoWindowRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $map = $event->getMap();
@@ -69,6 +73,7 @@ class DefaultInfoWindowSubscriber extends AbstractInfoWindowSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/EncodedPolylineSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/EncodedPolylineSubscriber.php
@@ -54,7 +54,9 @@ class EncodedPolylineSubscriber extends AbstractSubscriber
     {
         return $this->encodedPolylineCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setEncodedPolylineCollector(EncodedPolylineCollector $encodedPolylineCollector)
     {
         $this->encodedPolylineCollector = $encodedPolylineCollector;
@@ -67,12 +69,16 @@ class EncodedPolylineSubscriber extends AbstractSubscriber
     {
         return $this->encodedPolylineRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setEncodedPolylineRenderer(EncodedPolylineRenderer $encodedPolylineRenderer)
     {
         $this->encodedPolylineRenderer = $encodedPolylineRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleApi(ApiEvent $event)
     {
         foreach ($event->getObjects(Map::class) as $map) {
@@ -85,7 +91,9 @@ class EncodedPolylineSubscriber extends AbstractSubscriber
             }
         }
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -103,6 +111,7 @@ class EncodedPolylineSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/ExtendableSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/ExtendableSubscriber.php
@@ -51,7 +51,9 @@ class ExtendableSubscriber extends AbstractSubscriber
     {
         return $this->extendableCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setExtendableCollector(ExtendableCollector $extendableCollector)
     {
         $this->extendableCollector = $extendableCollector;
@@ -64,12 +66,16 @@ class ExtendableSubscriber extends AbstractSubscriber
     {
         return $this->extendableRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setExtendableRenderer(ExtendableRenderer $extendableRenderer)
     {
         $this->extendableRenderer = $extendableRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -82,6 +88,7 @@ class ExtendableSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/GroundOverlaySubscriber.php
+++ b/src/Helper/Subscriber/Overlay/GroundOverlaySubscriber.php
@@ -51,7 +51,9 @@ class GroundOverlaySubscriber extends AbstractSubscriber
     {
         return $this->groundOverlayCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setGroundOverlayCollector(GroundOverlayCollector $groundOverlayCollector)
     {
         $this->groundOverlayCollector = $groundOverlayCollector;
@@ -64,12 +66,16 @@ class GroundOverlaySubscriber extends AbstractSubscriber
     {
         return $this->groundOverlayRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setGroundOverlayRenderer(GroundOverlayRenderer $groundOverlayRenderer)
     {
         $this->groundOverlayRenderer = $groundOverlayRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class GroundOverlaySubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/IconSequenceSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/IconSequenceSubscriber.php
@@ -51,7 +51,9 @@ class IconSequenceSubscriber extends AbstractSubscriber
     {
         return $this->iconSequenceCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setIconSequenceCollector(IconSequenceCollector $iconSequenceCollector)
     {
         $this->iconSequenceCollector = $iconSequenceCollector;
@@ -64,12 +66,16 @@ class IconSequenceSubscriber extends AbstractSubscriber
     {
         return $this->iconSequenceRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setIconSequenceRenderer(IconSequenceRenderer $iconSequenceRenderer)
     {
         $this->iconSequenceRenderer = $iconSequenceRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class IconSequenceSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/IconSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/IconSubscriber.php
@@ -51,7 +51,9 @@ class IconSubscriber extends AbstractSubscriber
     {
         return $this->iconCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setIconCollector(IconCollector $iconCollector)
     {
         $this->iconCollector = $iconCollector;
@@ -64,12 +66,16 @@ class IconSubscriber extends AbstractSubscriber
     {
         return $this->iconRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setIconRenderer(IconRenderer $iconRenderer)
     {
         $this->iconRenderer = $iconRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class IconSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/InfoBoxSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/InfoBoxSubscriber.php
@@ -49,12 +49,16 @@ class InfoBoxSubscriber extends AbstractInfoWindowSubscriber
     {
         return $this->infoBoxRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setInfoBoxRenderer(InfoBoxRenderer $infoBoxRenderer)
     {
         $this->infoBoxRenderer = $infoBoxRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleApi(ApiEvent $event)
     {
         foreach ($event->getObjects(Map::class) as $map) {
@@ -68,7 +72,9 @@ class InfoBoxSubscriber extends AbstractInfoWindowSubscriber
             }
         }
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $map = $event->getMap();
@@ -85,6 +91,7 @@ class InfoBoxSubscriber extends AbstractInfoWindowSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/InfoWindowCloseSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/InfoWindowCloseSubscriber.php
@@ -44,12 +44,16 @@ class InfoWindowCloseSubscriber extends AbstractInfoWindowSubscriber
     {
         return $this->infoWindowCloseRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setInfoWindowCloseRenderer(InfoWindowCloseRenderer $infoWindowCloseRenderer)
     {
         $this->infoWindowCloseRenderer = $infoWindowCloseRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -71,6 +75,7 @@ class InfoWindowCloseSubscriber extends AbstractInfoWindowSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/InfoWindowOpenSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/InfoWindowOpenSubscriber.php
@@ -44,12 +44,16 @@ class InfoWindowOpenSubscriber extends AbstractInfoWindowSubscriber
     {
         return $this->infoWindowOpenRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setInfoWindowOpenRenderer(InfoWindowOpenRenderer $infoWindowOpenRenderer)
     {
         $this->infoWindowOpenRenderer = $infoWindowOpenRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -64,6 +68,7 @@ class InfoWindowOpenSubscriber extends AbstractInfoWindowSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/MarkerClustererSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/MarkerClustererSubscriber.php
@@ -46,12 +46,16 @@ class MarkerClustererSubscriber extends AbstractSubscriber
     {
         return $this->markerClustererRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setMarkerClustererRenderer(MarkerClustererRenderer $markerClustererRenderer)
     {
         $this->markerClustererRenderer = $markerClustererRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleApi(ApiEvent $event)
     {
         foreach ($event->getObjects(Map::class) as $map) {
@@ -63,7 +67,9 @@ class MarkerClustererSubscriber extends AbstractSubscriber
             }
         }
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -83,6 +89,7 @@ class MarkerClustererSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/MarkerInfoWindowOpenSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/MarkerInfoWindowOpenSubscriber.php
@@ -55,7 +55,9 @@ class MarkerInfoWindowOpenSubscriber extends AbstractMarkerSubscriber
     {
         return $this->infoWindowOpenRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setInfoWindowOpenRenderer(InfoWindowOpenRenderer $infoWindowOpenRenderer)
     {
         $this->infoWindowOpenRenderer = $infoWindowOpenRenderer;
@@ -68,12 +70,16 @@ class MarkerInfoWindowOpenSubscriber extends AbstractMarkerSubscriber
     {
         return $this->eventRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setEventRenderer(EventRenderer $eventRenderer)
     {
         $this->eventRenderer = $eventRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -97,6 +103,7 @@ class MarkerInfoWindowOpenSubscriber extends AbstractMarkerSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/MarkerShapeSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/MarkerShapeSubscriber.php
@@ -51,7 +51,9 @@ class MarkerShapeSubscriber extends AbstractSubscriber
     {
         return $this->markerShapeCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setMarkerShapeCollector(MarkerShapeCollector $markerShapeCollector)
     {
         $this->markerShapeCollector = $markerShapeCollector;
@@ -64,12 +66,16 @@ class MarkerShapeSubscriber extends AbstractSubscriber
     {
         return $this->markerShapeRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setMarkerShapeRenderer(MarkerShapeRenderer $markerShapeRenderer)
     {
         $this->markerShapeRenderer = $markerShapeRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class MarkerShapeSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/MarkerSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/MarkerSubscriber.php
@@ -45,12 +45,16 @@ class MarkerSubscriber extends AbstractMarkerSubscriber
     {
         return $this->markerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setMarkerRenderer(MarkerRenderer $markerRenderer)
     {
         $this->markerRenderer = $markerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -73,6 +77,7 @@ class MarkerSubscriber extends AbstractMarkerSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/PolygonSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/PolygonSubscriber.php
@@ -51,7 +51,9 @@ class PolygonSubscriber extends AbstractSubscriber
     {
         return $this->polygonCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setPolygonCollector(PolygonCollector $polygonCollector)
     {
         $this->polygonCollector = $polygonCollector;
@@ -64,12 +66,16 @@ class PolygonSubscriber extends AbstractSubscriber
     {
         return $this->polygonRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setPolygonRenderer(PolygonRenderer $polygonRenderer)
     {
         $this->polygonRenderer = $polygonRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class PolygonSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/PolylineSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/PolylineSubscriber.php
@@ -51,7 +51,9 @@ class PolylineSubscriber extends AbstractSubscriber
     {
         return $this->polylineCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setPolylineCollector(PolylineCollector $polylineCollector)
     {
         $this->polylineCollector = $polylineCollector;
@@ -64,12 +66,16 @@ class PolylineSubscriber extends AbstractSubscriber
     {
         return $this->polylineRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setPolylineRenderer(PolylineRenderer $polylineRenderer)
     {
         $this->polylineRenderer = $polylineRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class PolylineSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/RectangleSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/RectangleSubscriber.php
@@ -51,7 +51,9 @@ class RectangleSubscriber extends AbstractSubscriber
     {
         return $this->rectangleCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setRectangleCollector(RectangleCollector $rectangleCollector)
     {
         $this->rectangleCollector = $rectangleCollector;
@@ -64,12 +66,16 @@ class RectangleSubscriber extends AbstractSubscriber
     {
         return $this->rectangleRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setRectangleRenderer(RectangleRenderer $rectangleRenderer)
     {
         $this->rectangleRenderer = $rectangleRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class RectangleSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Overlay/SymbolSubscriber.php
+++ b/src/Helper/Subscriber/Overlay/SymbolSubscriber.php
@@ -51,7 +51,9 @@ class SymbolSubscriber extends AbstractSubscriber
     {
         return $this->symbolCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setSymbolCollector(SymbolCollector $symbolCollector)
     {
         $this->symbolCollector = $symbolCollector;
@@ -64,12 +66,16 @@ class SymbolSubscriber extends AbstractSubscriber
     {
         return $this->symbolRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setSymbolRenderer(SymbolRenderer $symbolRenderer)
     {
         $this->symbolRenderer = $symbolRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class SymbolSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Place/AutocompleteContainerSubscriber.php
+++ b/src/Helper/Subscriber/Place/AutocompleteContainerSubscriber.php
@@ -41,12 +41,16 @@ class AutocompleteContainerSubscriber extends AbstractSubscriber
     {
         return $this->containerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setContainerRenderer(AutocompleteContainerRenderer $containerRenderer)
     {
         $this->containerRenderer = $containerRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleAutocomplete(PlaceAutocompleteEvent $event)
     {
         $autocomplete = $event->getAutocomplete();
@@ -59,6 +63,7 @@ class AutocompleteContainerSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Place/AutocompleteHtmlSubscriber.php
+++ b/src/Helper/Subscriber/Place/AutocompleteHtmlSubscriber.php
@@ -41,12 +41,16 @@ class AutocompleteHtmlSubscriber extends AbstractSubscriber
     {
         return $this->htmlRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setHtmlRenderer(AutocompleteHtmlRenderer $htmlRenderer)
     {
         $this->htmlRenderer = $htmlRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleAutocomplete(PlaceAutocompleteEvent $event)
     {
         $event->addCode($this->htmlRenderer->render($event->getAutocomplete()));
@@ -54,6 +58,7 @@ class AutocompleteHtmlSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Place/AutocompleteJavascriptSubscriber.php
+++ b/src/Helper/Subscriber/Place/AutocompleteJavascriptSubscriber.php
@@ -64,7 +64,9 @@ class AutocompleteJavascriptSubscriber extends AbstractDelegateSubscriber
     {
         return $this->autocompleteRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setAutocompleteRenderer(AutocompleteRenderer $autocompleteRenderer)
     {
         $this->autocompleteRenderer = $autocompleteRenderer;
@@ -77,7 +79,9 @@ class AutocompleteJavascriptSubscriber extends AbstractDelegateSubscriber
     {
         return $this->callbackRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setCallbackRenderer(CallbackRenderer $callbackRenderer)
     {
         $this->callbackRenderer = $callbackRenderer;
@@ -90,7 +94,9 @@ class AutocompleteJavascriptSubscriber extends AbstractDelegateSubscriber
     {
         return $this->javascriptTagRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setJavascriptTagRenderer(JavascriptTagRenderer $javascriptTagRenderer)
     {
         $this->javascriptTagRenderer = $javascriptTagRenderer;
@@ -125,7 +131,9 @@ class AutocompleteJavascriptSubscriber extends AbstractDelegateSubscriber
             ],
         ];
     }
-
+    /**
+     * @return void
+     */
     private function handleApi(ApiEvent $event)
     {
         foreach ($event->getObjects(Autocomplete::class) as $autocomplete) {
@@ -134,7 +142,9 @@ class AutocompleteJavascriptSubscriber extends AbstractDelegateSubscriber
             $event->addRequirement($autocomplete, $this->autocompleteRenderer->renderRequirement());
         }
     }
-
+    /**
+     * @return void
+     */
     private function handleAutocomplete(PlaceAutocompleteEvent $event)
     {
         $formatter = $this->getFormatter();

--- a/src/Helper/Subscriber/Place/AutocompleteSubscriber.php
+++ b/src/Helper/Subscriber/Place/AutocompleteSubscriber.php
@@ -41,12 +41,16 @@ class AutocompleteSubscriber extends AbstractSubscriber
     {
         return $this->autocompleteRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setAutocompleteRenderer(AutocompleteRenderer $autocompleteRenderer)
     {
         $this->autocompleteRenderer = $autocompleteRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleAutocomplete(PlaceAutocompleteEvent $event)
     {
         $autocomplete = $event->getAutocomplete();
@@ -60,6 +64,7 @@ class AutocompleteSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Place/Base/AutocompleteBoundSubscriber.php
+++ b/src/Helper/Subscriber/Place/Base/AutocompleteBoundSubscriber.php
@@ -51,7 +51,9 @@ class AutocompleteBoundSubscriber extends AbstractSubscriber
     {
         return $this->boundCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setBoundCollector(AutocompleteBoundCollector $boundCollector)
     {
         $this->boundCollector = $boundCollector;
@@ -64,12 +66,16 @@ class AutocompleteBoundSubscriber extends AbstractSubscriber
     {
         return $this->boundRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setBoundRenderer(BoundRenderer $boundRenderer)
     {
         $this->boundRenderer = $boundRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleAutocomplete(PlaceAutocompleteEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class AutocompleteBoundSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Place/Base/AutocompleteCoordinateSubscriber.php
+++ b/src/Helper/Subscriber/Place/Base/AutocompleteCoordinateSubscriber.php
@@ -51,7 +51,9 @@ class AutocompleteCoordinateSubscriber extends AbstractSubscriber
     {
         return $this->coordinateCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setCoordinateCollector(AutocompleteCoordinateCollector $coordinateCollector)
     {
         $this->coordinateCollector = $coordinateCollector;
@@ -64,12 +66,16 @@ class AutocompleteCoordinateSubscriber extends AbstractSubscriber
     {
         return $this->coordinateRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setCoordinateRenderer(CoordinateRenderer $coordinateRenderer)
     {
         $this->coordinateRenderer = $coordinateRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleAutocomplete(PlaceAutocompleteEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class AutocompleteCoordinateSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Place/Event/AutocompleteDomEventOnceSubscriber.php
+++ b/src/Helper/Subscriber/Place/Event/AutocompleteDomEventOnceSubscriber.php
@@ -51,7 +51,9 @@ class AutocompleteDomEventOnceSubscriber extends AbstractSubscriber
     {
         return $this->domEventOnceCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setDomEventOnceCollector(AutocompleteDomEventOnceCollector $domEventOnceCollector)
     {
         $this->domEventOnceCollector = $domEventOnceCollector;
@@ -64,12 +66,16 @@ class AutocompleteDomEventOnceSubscriber extends AbstractSubscriber
     {
         return $this->domEventOnceRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setDomEventOnceRenderer(DomEventOnceRenderer $domEventOnceRenderer)
     {
         $this->domEventOnceRenderer = $domEventOnceRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleAutocomplete(PlaceAutocompleteEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class AutocompleteDomEventOnceSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Place/Event/AutocompleteDomEventSubscriber.php
+++ b/src/Helper/Subscriber/Place/Event/AutocompleteDomEventSubscriber.php
@@ -51,7 +51,9 @@ class AutocompleteDomEventSubscriber extends AbstractSubscriber
     {
         return $this->domEventCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setDomEventCollector(AutocompleteDomEventCollector $domEventCollector)
     {
         $this->domEventCollector = $domEventCollector;
@@ -64,12 +66,16 @@ class AutocompleteDomEventSubscriber extends AbstractSubscriber
     {
         return $this->domEventRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setDomEventRenderer(DomEventRenderer $domEventRenderer)
     {
         $this->domEventRenderer = $domEventRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleAutocomplete(PlaceAutocompleteEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class AutocompleteDomEventSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Place/Event/AutocompleteEventOnceSubscriber.php
+++ b/src/Helper/Subscriber/Place/Event/AutocompleteEventOnceSubscriber.php
@@ -51,7 +51,9 @@ class AutocompleteEventOnceSubscriber extends AbstractSubscriber
     {
         return $this->eventOnceCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setEventOnceCollector(AutocompleteEventOnceCollector $eventOnceCollector)
     {
         $this->eventOnceCollector = $eventOnceCollector;
@@ -64,12 +66,16 @@ class AutocompleteEventOnceSubscriber extends AbstractSubscriber
     {
         return $this->eventOnceRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setEventOnceRenderer(EventOnceRenderer $eventOnceRenderer)
     {
         $this->eventOnceRenderer = $eventOnceRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleAutocomplete(PlaceAutocompleteEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class AutocompleteEventOnceSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Place/Event/AutocompleteSimpleEventSubscriber.php
+++ b/src/Helper/Subscriber/Place/Event/AutocompleteSimpleEventSubscriber.php
@@ -51,7 +51,9 @@ class AutocompleteSimpleEventSubscriber extends AbstractSubscriber
     {
         return $this->eventCollector;
     }
-
+    /**
+     * @return void
+     */
     public function setEventCollector(AutocompleteEventCollector $eventCollector)
     {
         $this->eventCollector = $eventCollector;
@@ -64,12 +66,16 @@ class AutocompleteSimpleEventSubscriber extends AbstractSubscriber
     {
         return $this->eventRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setEventRenderer(EventRenderer $eventRenderer)
     {
         $this->eventRenderer = $eventRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleAutocomplete(PlaceAutocompleteEvent $event)
     {
         $formatter = $this->getFormatter();
@@ -87,6 +93,7 @@ class AutocompleteSimpleEventSubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Helper/Subscriber/Utility/ObjectToArraySubscriber.php
+++ b/src/Helper/Subscriber/Utility/ObjectToArraySubscriber.php
@@ -41,12 +41,16 @@ class ObjectToArraySubscriber extends AbstractSubscriber
     {
         return $this->objectToArrayRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function setObjectToArrayRenderer(ObjectToArrayRenderer $objectToArrayRenderer)
     {
         $this->objectToArrayRenderer = $objectToArrayRenderer;
     }
-
+    /**
+     * @return void
+     */
     public function handleMap(MapEvent $event)
     {
         $event->addCode($this->getFormatter()->renderContainerAssignment(
@@ -58,6 +62,7 @@ class ObjectToArraySubscriber extends AbstractSubscriber
 
     /**
      * {@inheritdoc}
+     * @return array<string,string>
      */
     public static function getSubscribedEvents()
     {

--- a/src/Layer/GeoJsonLayer.php
+++ b/src/Layer/GeoJsonLayer.php
@@ -46,6 +46,7 @@ class GeoJsonLayer implements OptionsAwareInterface
 
     /**
      * @param string $url
+     * @return void
      */
     public function setUrl($url)
     {

--- a/src/Layer/HeatmapLayer.php
+++ b/src/Layer/HeatmapLayer.php
@@ -58,6 +58,7 @@ class HeatmapLayer implements ExtendableInterface, OptionsAwareInterface
 
     /**
      * @param Coordinate[] $coordinates
+     * @return void
      */
     public function setCoordinates(array $coordinates)
     {
@@ -67,6 +68,7 @@ class HeatmapLayer implements ExtendableInterface, OptionsAwareInterface
 
     /**
      * @param Coordinate[] $coordinates
+     * @return void
      */
     public function addCoordinates(array $coordinates)
     {
@@ -82,14 +84,18 @@ class HeatmapLayer implements ExtendableInterface, OptionsAwareInterface
     {
         return in_array($coordinate, $this->coordinates, true);
     }
-
+    /**
+     * @return void
+     */
     public function addCoordinate(Coordinate $coordinate)
     {
         if (!$this->hasCoordinate($coordinate)) {
             $this->coordinates[] = $coordinate;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeCoordinate(Coordinate $coordinate)
     {
         unset($this->coordinates[array_search($coordinate, $this->coordinates, true)]);

--- a/src/Layer/KmlLayer.php
+++ b/src/Layer/KmlLayer.php
@@ -49,6 +49,7 @@ class KmlLayer implements ExtendableInterface, OptionsAwareInterface
 
     /**
      * @param string $url
+     * @return void
      */
     public function setUrl($url)
     {

--- a/src/Layer/LayerManager.php
+++ b/src/Layer/LayerManager.php
@@ -54,7 +54,9 @@ class LayerManager
     {
         return $this->map;
     }
-
+    /**
+     * @return void
+     */
     public function setMap(Map $map)
     {
         $this->map = $map;
@@ -82,6 +84,7 @@ class LayerManager
 
     /**
      * @param GeoJsonLayer[] $geoJsonLayers
+     * @return void
      */
     public function setGeoJsonLayers(array $geoJsonLayers)
     {
@@ -91,6 +94,7 @@ class LayerManager
 
     /**
      * @param GeoJsonLayer[] $geoJsonLayers
+     * @return void
      */
     public function addGeoJsonLayers(array $geoJsonLayers)
     {
@@ -106,14 +110,18 @@ class LayerManager
     {
         return in_array($geoJsonLayer, $this->geoJsonLayers, true);
     }
-
+    /**
+     * @return void
+     */
     public function addGeoJsonLayer(GeoJsonLayer $geoJsonLayer)
     {
         if (!$this->hasGeoJsonLayer($geoJsonLayer)) {
             $this->geoJsonLayers[] = $geoJsonLayer;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeGeoJsonLayer(GeoJsonLayer $geoJsonLayer)
     {
         unset($this->geoJsonLayers[array_search($geoJsonLayer, $this->geoJsonLayers, true)]);
@@ -138,6 +146,7 @@ class LayerManager
 
     /**
      * @param HeatmapLayer[] $heatmapLayers
+     * @return void
      */
     public function setHeatmapLayers(array $heatmapLayers)
     {
@@ -150,6 +159,7 @@ class LayerManager
 
     /**
      * @param HeatmapLayer[] $heatmapLayers
+     * @return void
      */
     public function addHeatmapLayers(array $heatmapLayers)
     {
@@ -165,7 +175,9 @@ class LayerManager
     {
         return in_array($heatmapLayer, $this->heatmapLayers, true);
     }
-
+    /**
+     * @return void
+     */
     public function addHeatmapLayer(HeatmapLayer $heatmapLayer)
     {
         if (!$this->hasHeatmapLayer($heatmapLayer)) {
@@ -174,7 +186,9 @@ class LayerManager
 
         $this->addExtendable($heatmapLayer);
     }
-
+    /**
+     * @return void
+     */
     public function removeHeatmapLayer(HeatmapLayer $heatmapLayer)
     {
         unset($this->heatmapLayers[array_search($heatmapLayer, $this->heatmapLayers, true)]);
@@ -200,6 +214,7 @@ class LayerManager
 
     /**
      * @param KmlLayer[] $kmlLayers
+     * @return void
      */
     public function setKmlLayers(array $kmlLayers)
     {
@@ -212,6 +227,7 @@ class LayerManager
 
     /**
      * @param KmlLayer[] $kmlLayers
+     * @return void
      */
     public function addKmlLayers(array $kmlLayers)
     {
@@ -227,7 +243,9 @@ class LayerManager
     {
         return in_array($kmlLayer, $this->kmlLayers, true);
     }
-
+    /**
+     * @return void
+     */
     public function addKmlLayer(KmlLayer $kmlLayer)
     {
         if (!$this->hasKmlLayer($kmlLayer)) {
@@ -236,21 +254,27 @@ class LayerManager
 
         $this->addExtendable($kmlLayer);
     }
-
+    /**
+     * @return void
+     */
     public function removeKmlLayer(KmlLayer $kmlLayer)
     {
         unset($this->kmlLayers[array_search($kmlLayer, $this->kmlLayers, true)]);
         $this->kmlLayers = empty($this->kmlLayers) ? [] : array_values($this->kmlLayers);
         $this->removeExtendable($kmlLayer);
     }
-
+    /**
+     * @return void
+     */
     private function addExtendable(ExtendableInterface $extendable)
     {
         if ($this->isAutoZoom()) {
             $this->getMap()->getBound()->addExtendable($extendable);
         }
     }
-
+    /**
+     * @return void
+     */
     private function removeExtendable(ExtendableInterface $extendable)
     {
         if ($this->isAutoZoom()) {

--- a/src/Map.php
+++ b/src/Map.php
@@ -112,6 +112,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param string $htmlId
+     * @return void
      */
     public function setHtmlId($htmlId)
     {
@@ -128,6 +129,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param bool $autoZoom
+     * @return void
      */
     public function setAutoZoom($autoZoom)
     {
@@ -141,7 +143,9 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
     {
         return $this->center;
     }
-
+    /**
+     * @return void
+     */
     public function setCenter(Coordinate $center)
     {
         $this->center = $center;
@@ -154,7 +158,9 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
     {
         return $this->bound;
     }
-
+    /**
+     * @return void
+     */
     public function setBound(Bound $bound)
     {
         $this->bound = $bound;
@@ -167,7 +173,9 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
     {
         return $this->controlManager;
     }
-
+    /**
+     * @return void
+     */
     public function setControlManager(ControlManager $controlManager)
     {
         $this->controlManager = $controlManager;
@@ -180,7 +188,9 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
     {
         return $this->eventManager;
     }
-
+    /**
+     * @return void
+     */
     public function setEventManager(EventManager $eventManager)
     {
         $this->eventManager = $eventManager;
@@ -193,7 +203,9 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
     {
         return $this->layerManager;
     }
-
+    /**
+     * @return void
+     */
     public function setLayerManager(LayerManager $layerManager)
     {
         $this->layerManager = $layerManager;
@@ -210,7 +222,9 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
     {
         return $this->overlayManager;
     }
-
+    /**
+     * @return void
+     */
     public function setOverlayManager(OverlayManager $overlayManager)
     {
         $this->overlayManager = $overlayManager;
@@ -238,6 +252,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param string[] $libraries
+     * @return void
      */
     public function setLibraries(array $libraries)
     {
@@ -247,6 +262,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param string[] $libraries
+     * @return void
      */
     public function addLibraries(array $libraries)
     {
@@ -267,6 +283,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param string $library
+     * @return void
      */
     public function addLibrary($library)
     {
@@ -277,6 +294,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param string $library
+     * @return void
      */
     public function removeLibrary($library)
     {
@@ -302,6 +320,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param mixed[] $mapOptions
+     * @return void
      */
     public function setMapOptions(array $mapOptions)
     {
@@ -311,6 +330,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param mixed[] $mapOptions
+     * @return void
      */
     public function addMapOptions(array $mapOptions)
     {
@@ -342,6 +362,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
     /**
      * @param string $mapOption
      * @param mixed  $value
+     * @return void
      */
     public function setMapOption($mapOption, $value)
     {
@@ -350,6 +371,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param string $mapOption
+     * @return void
      */
     public function removeMapOption($mapOption)
     {
@@ -374,6 +396,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param string[] $stylesheetOptions
+     * @return void
      */
     public function setStylesheetOptions(array $stylesheetOptions)
     {
@@ -383,6 +406,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param string[] $stylesheetOptions
+     * @return void
      */
     public function addStylesheetOptions(array $stylesheetOptions)
     {
@@ -414,6 +438,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
     /**
      * @param string $stylesheetOption
      * @param string $value
+     * @return void
      */
     public function setStylesheetOption($stylesheetOption, $value)
     {
@@ -422,6 +447,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param string $stylesheetOption
+     * @return void
      */
     public function removeStylesheetOption($stylesheetOption)
     {
@@ -446,6 +472,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param string[] $htmlAttributes
+     * @return void
      */
     public function setHtmlAttributes(array $htmlAttributes)
     {
@@ -455,6 +482,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param string[] $htmlAttributes
+     * @return void
      */
     public function addHtmlAttributes(array $htmlAttributes)
     {
@@ -486,6 +514,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
     /**
      * @param string $htmlAttribute
      * @param string $value
+     * @return void
      */
     public function setHtmlAttribute($htmlAttribute, $value)
     {
@@ -494,6 +523,7 @@ class Map implements VariableAwareInterface, StaticOptionsAwareInterface
 
     /**
      * @param string $htmlAttribute
+     * @return void
      */
     public function removeHtmlAttribute($htmlAttribute)
     {

--- a/src/Overlay/Circle.php
+++ b/src/Overlay/Circle.php
@@ -54,7 +54,9 @@ class Circle implements ExtendableInterface, OptionsAwareInterface
     {
         return $this->center;
     }
-
+    /**
+     * @return void
+     */
     public function setCenter(Coordinate $center)
     {
         $this->center = $center;
@@ -70,6 +72,7 @@ class Circle implements ExtendableInterface, OptionsAwareInterface
 
     /**
      * @param float $radius
+     * @return void
      */
     public function setRadius($radius)
     {

--- a/src/Overlay/EncodedPolyline.php
+++ b/src/Overlay/EncodedPolyline.php
@@ -55,6 +55,7 @@ class EncodedPolyline implements ExtendableInterface, OptionsAwareInterface, Sta
 
     /**
      * @param string $value
+     * @return void
      */
     public function setValue($value)
     {

--- a/src/Overlay/GroundOverlay.php
+++ b/src/Overlay/GroundOverlay.php
@@ -57,6 +57,7 @@ class GroundOverlay implements ExtendableInterface, OptionsAwareInterface
 
     /**
      * @param string $url
+     * @return void
      */
     public function setUrl($url)
     {
@@ -70,7 +71,9 @@ class GroundOverlay implements ExtendableInterface, OptionsAwareInterface
     {
         return $this->bound;
     }
-
+    /**
+     * @return void
+     */
     public function setBound(Bound $bound)
     {
         $this->bound = $bound;

--- a/src/Overlay/Icon.php
+++ b/src/Overlay/Icon.php
@@ -86,6 +86,7 @@ class Icon implements VariableAwareInterface
 
     /**
      * @param string $url
+     * @return void
      */
     public function setUrl($url)
     {
@@ -107,7 +108,9 @@ class Icon implements VariableAwareInterface
     {
         return $this->anchor;
     }
-
+    /**
+     * @return void
+     */
     public function setAnchor(?Point $anchor = null)
     {
         $this->anchor = $anchor;
@@ -128,7 +131,9 @@ class Icon implements VariableAwareInterface
     {
         return $this->origin;
     }
-
+    /**
+     * @return void
+     */
     public function setOrigin(?Point $origin = null)
     {
         $this->origin = $origin;
@@ -149,7 +154,9 @@ class Icon implements VariableAwareInterface
     {
         return $this->scaledSize;
     }
-
+    /**
+     * @return void
+     */
     public function setScaledSize(?Size $scaledSize = null)
     {
         $this->scaledSize = $scaledSize;
@@ -170,7 +177,9 @@ class Icon implements VariableAwareInterface
     {
         return $this->size;
     }
-
+    /**
+     * @return void
+     */
     public function setSize(Size $size = null)
     {
         $this->size = $size;
@@ -191,7 +200,9 @@ class Icon implements VariableAwareInterface
     {
         return $this->labelOrigin;
     }
-
+    /**
+     * @return void
+     */
     public function setLabelOrigin(Point $labelOrigin = null)
     {
         $this->labelOrigin = $labelOrigin;

--- a/src/Overlay/IconSequence.php
+++ b/src/Overlay/IconSequence.php
@@ -47,7 +47,9 @@ class IconSequence implements OptionsAwareInterface, VariableAwareInterface
     {
         return $this->symbol;
     }
-
+    /**
+     * @return void
+     */
     public function setSymbol(Symbol $symbol)
     {
         $this->symbol = $symbol;

--- a/src/Overlay/InfoWindow.php
+++ b/src/Overlay/InfoWindow.php
@@ -89,6 +89,7 @@ class InfoWindow implements ExtendableInterface, OptionsAwareInterface
 
     /**
      * @param string $content
+     * @return void
      */
     public function setContent($content)
     {
@@ -105,6 +106,7 @@ class InfoWindow implements ExtendableInterface, OptionsAwareInterface
 
     /**
      * @param string $type
+     * @return void
      */
     public function setType($type)
     {
@@ -126,7 +128,9 @@ class InfoWindow implements ExtendableInterface, OptionsAwareInterface
     {
         return $this->position;
     }
-
+    /**
+     * @return void
+     */
     public function setPosition(?Coordinate $position = null)
     {
         $this->position = $position;
@@ -147,7 +151,9 @@ class InfoWindow implements ExtendableInterface, OptionsAwareInterface
     {
         return $this->pixedOffset;
     }
-
+    /**
+     * @return void
+     */
     public function setPixelOffset(?Size $pixelOffset = null)
     {
         $this->pixedOffset = $pixelOffset;
@@ -163,6 +169,7 @@ class InfoWindow implements ExtendableInterface, OptionsAwareInterface
 
     /**
      * @param bool $open
+     * @return void
      */
     public function setOpen($open)
     {
@@ -179,6 +186,7 @@ class InfoWindow implements ExtendableInterface, OptionsAwareInterface
 
     /**
      * @param bool $autoOpen
+     * @return void
      */
     public function setAutoOpen($autoOpen)
     {
@@ -195,6 +203,7 @@ class InfoWindow implements ExtendableInterface, OptionsAwareInterface
 
     /**
      * @param string $openEvent
+     * @return void
      */
     public function setOpenEvent($openEvent)
     {
@@ -211,6 +220,7 @@ class InfoWindow implements ExtendableInterface, OptionsAwareInterface
 
     /**
      * @param bool $autoClose
+     * @return void
      */
     public function setAutoClose($autoClose)
     {

--- a/src/Overlay/Marker.php
+++ b/src/Overlay/Marker.php
@@ -90,7 +90,9 @@ class Marker implements ExtendableInterface, OptionsAwareInterface, StaticOption
     {
         return $this->position;
     }
-
+    /**
+     * @return void
+     */
     public function setPosition(Coordinate $position)
     {
         $this->position = $position;
@@ -114,6 +116,7 @@ class Marker implements ExtendableInterface, OptionsAwareInterface, StaticOption
 
     /**
      * @param string|null $animation
+     * @return void
      */
     public function setAnimation($animation = null)
     {
@@ -135,7 +138,9 @@ class Marker implements ExtendableInterface, OptionsAwareInterface, StaticOption
     {
         return $this->icon;
     }
-
+    /**
+     * @return void
+     */
     public function setIcon(?Icon $icon = null)
     {
         $this->icon = $icon;
@@ -160,7 +165,9 @@ class Marker implements ExtendableInterface, OptionsAwareInterface, StaticOption
     {
         return $this->symbol;
     }
-
+    /**
+     * @return void
+     */
     public function setSymbol(?Symbol $symbol = null)
     {
         $this->symbol = $symbol;
@@ -185,7 +192,9 @@ class Marker implements ExtendableInterface, OptionsAwareInterface, StaticOption
     {
         return $this->shape;
     }
-
+    /**
+     * @return void
+     */
     public function setShape(?MarkerShape $shape = null)
     {
         $this->shape = $shape;
@@ -206,7 +215,9 @@ class Marker implements ExtendableInterface, OptionsAwareInterface, StaticOption
     {
         return $this->infoWindow;
     }
-
+    /**
+     * @return void
+     */
     public function setInfoWindow(?InfoWindow $infoWindow = null)
     {
         $this->infoWindow = $infoWindow;

--- a/src/Overlay/MarkerCluster.php
+++ b/src/Overlay/MarkerCluster.php
@@ -54,7 +54,9 @@ class MarkerCluster implements OptionsAwareInterface, VariableAwareInterface
     {
         return $this->overlayManager;
     }
-
+    /**
+     * @return void
+     */
     public function setOverlayManager(OverlayManager $overlayManager)
     {
         $this->overlayManager = $overlayManager;
@@ -74,6 +76,7 @@ class MarkerCluster implements OptionsAwareInterface, VariableAwareInterface
 
     /**
      * @param string $type
+     * @return void
      */
     public function setType($type)
     {
@@ -98,6 +101,7 @@ class MarkerCluster implements OptionsAwareInterface, VariableAwareInterface
 
     /**
      * @param Marker[] $markers
+     * @return void
      */
     public function setMarkers(array $markers)
     {
@@ -110,6 +114,7 @@ class MarkerCluster implements OptionsAwareInterface, VariableAwareInterface
 
     /**
      * @param Marker[] $markers
+     * @return void
      */
     public function addMarkers(array $markers)
     {
@@ -125,7 +130,9 @@ class MarkerCluster implements OptionsAwareInterface, VariableAwareInterface
     {
         return in_array($marker, $this->markers, true);
     }
-
+    /**
+     * @return void
+     */
     public function addMarker(Marker $marker)
     {
         if (!$this->hasMarker($marker)) {
@@ -134,21 +141,27 @@ class MarkerCluster implements OptionsAwareInterface, VariableAwareInterface
 
         $this->addExtendable($marker);
     }
-
+    /**
+     * @return void
+     */
     public function removeMarker(Marker $marker)
     {
         unset($this->markers[array_search($marker, $this->markers, true)]);
         $this->markers = empty($this->markers) ? [] : array_values($this->markers);
         $this->removeExtendable($marker);
     }
-
+    /**
+     * @return void
+     */
     private function addExtendable(ExtendableInterface $extendable)
     {
         if ($this->isAutoZoom()) {
             $this->getOverlayManager()->getMap()->getBound()->addExtendable($extendable);
         }
     }
-
+    /**
+     * @return void
+     */
     private function removeExtendable(ExtendableInterface $extendable)
     {
         if ($this->isAutoZoom()) {

--- a/src/Overlay/MarkerShape.php
+++ b/src/Overlay/MarkerShape.php
@@ -53,6 +53,7 @@ class MarkerShape implements VariableAwareInterface
 
     /**
      * @param string $type
+     * @return void
      */
     public function setType($type)
     {
@@ -77,6 +78,7 @@ class MarkerShape implements VariableAwareInterface
 
     /**
      * @param float[] $coordinates
+     * @return void
      */
     public function setCoordinates(array $coordinates)
     {
@@ -86,6 +88,7 @@ class MarkerShape implements VariableAwareInterface
 
     /**
      * @param float[] $coordinates
+     * @return void
      */
     public function addCoordinates(array $coordinates)
     {
@@ -106,6 +109,7 @@ class MarkerShape implements VariableAwareInterface
 
     /**
      * @param float $coordinate
+     * @return void
      */
     public function addCoordinate($coordinate)
     {

--- a/src/Overlay/OverlayManager.php
+++ b/src/Overlay/OverlayManager.php
@@ -83,7 +83,9 @@ class OverlayManager
     {
         return $this->map;
     }
-
+    /**
+     * @return void
+     */
     public function setMap(Map $map)
     {
         $this->map = $map;
@@ -100,7 +102,9 @@ class OverlayManager
     {
         return $this->markerCluster;
     }
-
+    /**
+     * @return void
+     */
     public function setMarkerCluster(MarkerCluster $markerCluster)
     {
         $this->markerCluster = $markerCluster;
@@ -128,6 +132,7 @@ class OverlayManager
 
     /**
      * @param Marker[] $markers
+     * @return void
      */
     public function setMarkers(array $markers)
     {
@@ -136,6 +141,7 @@ class OverlayManager
 
     /**
      * @param Marker[] $markers
+     * @return void
      */
     public function addMarkers(array $markers)
     {
@@ -149,12 +155,16 @@ class OverlayManager
     {
         return $this->markerCluster->hasMarker($marker);
     }
-
+    /**
+     * @return void
+     */
     public function addMarker(Marker $marker)
     {
         $this->markerCluster->addMarker($marker);
     }
-
+    /**
+     * @return void
+     */
     public function removeMarker(Marker $marker)
     {
         $this->markerCluster->removeMarker($marker);
@@ -178,6 +188,7 @@ class OverlayManager
 
     /**
      * @param InfoWindow[] $infoWindows
+     * @return void
      */
     public function setInfoWindows(array $infoWindows)
     {
@@ -190,6 +201,7 @@ class OverlayManager
 
     /**
      * @param InfoWindow[] $infoWindows
+     * @return void
      */
     public function addInfoWindows(array $infoWindows)
     {
@@ -205,7 +217,9 @@ class OverlayManager
     {
         return in_array($infoWindow, $this->infoWindows, true);
     }
-
+    /**
+     * @return void
+     */
     public function addInfoWindow(InfoWindow $infoWindow)
     {
         if (!$this->hasInfoWindow($infoWindow)) {
@@ -214,7 +228,9 @@ class OverlayManager
 
         $this->addExtendable($infoWindow);
     }
-
+    /**
+     * @return void
+     */
     public function removeInfoWindow(InfoWindow $infoWindow)
     {
         unset($this->infoWindows[array_search($infoWindow, $this->infoWindows, true)]);
@@ -240,6 +256,7 @@ class OverlayManager
 
     /**
      * @param Polyline[] $polylines
+     * @return void
      */
     public function setPolylines(array $polylines)
     {
@@ -252,6 +269,7 @@ class OverlayManager
 
     /**
      * @param Polyline[] $polylines
+     * @return void
      */
     public function addPolylines(array $polylines)
     {
@@ -267,7 +285,9 @@ class OverlayManager
     {
         return in_array($polyline, $this->polylines, true);
     }
-
+    /**
+     * @return void
+     */
     public function addPolyline(Polyline $polyline)
     {
         if (!$this->hasPolyline($polyline)) {
@@ -276,7 +296,9 @@ class OverlayManager
 
         $this->addExtendable($polyline);
     }
-
+    /**
+     * @return void
+     */
     public function removePolyline(Polyline $polyline)
     {
         unset($this->polylines[array_search($polyline, $this->polylines, true)]);
@@ -302,6 +324,7 @@ class OverlayManager
 
     /**
      * @param EncodedPolyline[] $encodedPolylines
+     * @return void
      */
     public function setEncodedPolylines(array $encodedPolylines)
     {
@@ -314,6 +337,7 @@ class OverlayManager
 
     /**
      * @param EncodedPolyline[] $encodedPolylines
+     * @return void
      */
     public function addEncodedPolylines(array $encodedPolylines)
     {
@@ -329,7 +353,9 @@ class OverlayManager
     {
         return in_array($encodedPolyline, $this->encodedPolylines, true);
     }
-
+    /**
+     * @return void
+     */
     public function addEncodedPolyline(EncodedPolyline $encodedPolyline)
     {
         if (!$this->hasEncodedPolyline($encodedPolyline)) {
@@ -338,7 +364,9 @@ class OverlayManager
 
         $this->addExtendable($encodedPolyline);
     }
-
+    /**
+     * @return void
+     */
     public function removeEncodedPolyline(EncodedPolyline $encodedPolyline)
     {
         unset($this->encodedPolylines[array_search($encodedPolyline, $this->encodedPolylines, true)]);
@@ -364,6 +392,7 @@ class OverlayManager
 
     /**
      * @param Polygon[] $polygons
+     * @return void
      */
     public function setPolygons(array $polygons)
     {
@@ -376,6 +405,7 @@ class OverlayManager
 
     /**
      * @param Polygon[] $polygons
+     * @return void
      */
     public function addPolygons(array $polygons)
     {
@@ -391,7 +421,9 @@ class OverlayManager
     {
         return in_array($polygon, $this->polygons, true);
     }
-
+    /**
+     * @return void
+     */
     public function addPolygon(Polygon $polygon)
     {
         if (!$this->hasPolygon($polygon)) {
@@ -400,7 +432,9 @@ class OverlayManager
 
         $this->addExtendable($polygon);
     }
-
+    /**
+     * @return void
+     */
     public function removePolygon(Polygon $polygon)
     {
         unset($this->polygons[array_search($polygon, $this->polygons, true)]);
@@ -426,6 +460,7 @@ class OverlayManager
 
     /**
      * @param Rectangle[] $rectangles
+     * @return void
      */
     public function setRectangles(array $rectangles)
     {
@@ -438,6 +473,7 @@ class OverlayManager
 
     /**
      * @param Rectangle[] $rectangles
+     * @return void
      */
     public function addRectangles(array $rectangles)
     {
@@ -453,7 +489,9 @@ class OverlayManager
     {
         return in_array($rectangle, $this->rectangles, true);
     }
-
+    /**
+     * @return void
+     */
     public function addRectangle(Rectangle $rectangle)
     {
         if (!$this->hasRectangle($rectangle)) {
@@ -462,7 +500,9 @@ class OverlayManager
 
         $this->addExtendable($rectangle);
     }
-
+    /**
+     * @return void
+     */
     public function removeRectangle(Rectangle $rectangle)
     {
         unset($this->rectangles[array_search($rectangle, $this->rectangles, true)]);
@@ -488,6 +528,7 @@ class OverlayManager
 
     /**
      * @param Circle[] $circles
+     * @return void
      */
     public function setCircles(array $circles)
     {
@@ -500,6 +541,7 @@ class OverlayManager
 
     /**
      * @param Circle[] $circles
+     * @return void
      */
     public function addCircles(array $circles)
     {
@@ -515,7 +557,9 @@ class OverlayManager
     {
         return in_array($circle, $this->circles, true);
     }
-
+    /**
+     * @return void
+     */
     public function addCircle(Circle $circle)
     {
         if (!$this->hasCircle($circle)) {
@@ -524,7 +568,9 @@ class OverlayManager
 
         $this->addExtendable($circle);
     }
-
+    /**
+     * @return void
+     */
     public function removeCircle(Circle $circle)
     {
         unset($this->circles[array_search($circle, $this->circles, true)]);
@@ -550,6 +596,7 @@ class OverlayManager
 
     /**
      * @param GroundOverlay[] $groundOverlays
+     * @return void
      */
     public function setGroundOverlays(array $groundOverlays)
     {
@@ -562,6 +609,7 @@ class OverlayManager
 
     /**
      * @param GroundOverlay[] $groundOverlays
+     * @return void
      */
     public function addGroundOverlays(array $groundOverlays)
     {
@@ -577,7 +625,9 @@ class OverlayManager
     {
         return in_array($groundOverlay, $this->groundOverlays, true);
     }
-
+    /**
+     * @return void
+     */
     public function addGroundOverlay(GroundOverlay $groundOverlay)
     {
         if (!$this->hasGroundOverlay($groundOverlay)) {
@@ -586,21 +636,27 @@ class OverlayManager
 
         $this->addExtendable($groundOverlay);
     }
-
+    /**
+     * @return void
+     */
     public function removeGroundOverlay(GroundOverlay $groundOverlay)
     {
         unset($this->groundOverlays[array_search($groundOverlay, $this->groundOverlays, true)]);
         $this->groundOverlays = empty($this->groundOverlays) ? [] : array_values($this->groundOverlays);
         $this->removeExtendable($groundOverlay);
     }
-
+    /**
+     * @return void
+     */
     private function addExtendable(ExtendableInterface $extendable)
     {
         if ($this->isAutoZoom()) {
             $this->getMap()->getBound()->addExtendable($extendable);
         }
     }
-
+    /**
+     * @return void
+     */
     private function removeExtendable(ExtendableInterface $extendable)
     {
         if ($this->isAutoZoom()) {

--- a/src/Overlay/Polygon.php
+++ b/src/Overlay/Polygon.php
@@ -59,6 +59,7 @@ class Polygon implements ExtendableInterface, OptionsAwareInterface
 
     /**
      * @param Coordinate[] $coordinates
+     * @return void
      */
     public function setCoordinates(array $coordinates)
     {
@@ -68,6 +69,7 @@ class Polygon implements ExtendableInterface, OptionsAwareInterface
 
     /**
      * @param Coordinate[] $coordinates
+     * @return void
      */
     public function addCoordinates(array $coordinates)
     {
@@ -83,12 +85,16 @@ class Polygon implements ExtendableInterface, OptionsAwareInterface
     {
         return in_array($coordinate, $this->coordinates, true);
     }
-
+    /**
+     * @return void
+     */
     public function addCoordinate(Coordinate $coordinate)
     {
         $this->coordinates[] = $coordinate;
     }
-
+    /**
+     * @return void
+     */
     public function removeCoordinate(Coordinate $coordinate)
     {
         unset($this->coordinates[array_search($coordinate, $this->coordinates, true)]);

--- a/src/Overlay/Polyline.php
+++ b/src/Overlay/Polyline.php
@@ -69,6 +69,7 @@ class Polyline implements ExtendableInterface, OptionsAwareInterface, StaticOpti
 
     /**
      * @param Coordinate[] $coordinates
+     * @return void
      */
     public function setCoordinates($coordinates)
     {
@@ -78,6 +79,7 @@ class Polyline implements ExtendableInterface, OptionsAwareInterface, StaticOpti
 
     /**
      * @param Coordinate[] $coordinates
+     * @return void
      */
     public function addCoordinates($coordinates)
     {
@@ -93,12 +95,16 @@ class Polyline implements ExtendableInterface, OptionsAwareInterface, StaticOpti
     {
         return in_array($coordinate, $this->coordinates, true);
     }
-
+    /**
+     * @return void
+     */
     public function addCoordinate(Coordinate $coordinate)
     {
         $this->coordinates[] = $coordinate;
     }
-
+    /**
+     * @return void
+     */
     public function removeCoordinate(Coordinate $coordinate)
     {
         unset($this->coordinates[array_search($coordinate, $this->coordinates, true)]);
@@ -123,6 +129,7 @@ class Polyline implements ExtendableInterface, OptionsAwareInterface, StaticOpti
 
     /**
      * @param IconSequence[] $iconSequences
+     * @return void
      */
     public function setIconSequences($iconSequences)
     {
@@ -132,6 +139,7 @@ class Polyline implements ExtendableInterface, OptionsAwareInterface, StaticOpti
 
     /**
      * @param IconSequence[] $iconSequences
+     * @return void
      */
     public function addIconSequences($iconSequences)
     {
@@ -147,12 +155,16 @@ class Polyline implements ExtendableInterface, OptionsAwareInterface, StaticOpti
     {
         return in_array($iconSequence, $this->iconSequences, true);
     }
-
+    /**
+     * @return void
+     */
     public function addIconSequence(IconSequence $iconSequence)
     {
         $this->iconSequences[] = $iconSequence;
     }
-
+    /**
+     * @return void
+     */
     public function removeIconSequence(IconSequence $iconSequence)
     {
         unset($this->iconSequences[array_search($iconSequence, $this->iconSequences, true)]);

--- a/src/Overlay/Rectangle.php
+++ b/src/Overlay/Rectangle.php
@@ -45,7 +45,9 @@ class Rectangle implements ExtendableInterface, OptionsAwareInterface
     {
         return $this->bound;
     }
-
+    /**
+     * @return void
+     */
     public function setBound(Bound $bound)
     {
         $this->bound = $bound;

--- a/src/Overlay/Symbol.php
+++ b/src/Overlay/Symbol.php
@@ -63,6 +63,7 @@ class Symbol implements OptionsAwareInterface, VariableAwareInterface
 
     /**
      * @param string $path
+     * @return void
      */
     public function setPath($path)
     {
@@ -84,7 +85,9 @@ class Symbol implements OptionsAwareInterface, VariableAwareInterface
     {
         return $this->anchor;
     }
-
+    /**
+     * @return void
+     */
     public function setAnchor(?Point $anchor = null)
     {
         $this->anchor = $anchor;
@@ -105,7 +108,9 @@ class Symbol implements OptionsAwareInterface, VariableAwareInterface
     {
         return $this->labelOrigin;
     }
-
+    /**
+     * @return void
+     */
     public function setLabelOrigin(?Point $labelOrigin = null)
     {
         $this->labelOrigin = $labelOrigin;

--- a/src/Place/Autocomplete.php
+++ b/src/Place/Autocomplete.php
@@ -78,6 +78,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string $inputId
+     * @return void
      */
     public function setInputId($inputId)
     {
@@ -91,7 +92,9 @@ class Autocomplete implements VariableAwareInterface
     {
         return $this->eventManager;
     }
-
+    /**
+     * @return void
+     */
     public function setEventManager(EventManager $eventManager)
     {
         $this->eventManager = $eventManager;
@@ -112,7 +115,9 @@ class Autocomplete implements VariableAwareInterface
     {
         return $this->bound;
     }
-
+    /**
+     * @return void
+     */
     public function setBound(?Bound $bound = null)
     {
         $this->bound = $bound;
@@ -136,6 +141,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string[] $types
+     * @return void
      */
     public function setTypes(array $types)
     {
@@ -145,6 +151,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string[] $types
+     * @return void
      */
     public function addTypes(array $types)
     {
@@ -165,6 +172,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string $type
+     * @return void
      */
     public function addType($type)
     {
@@ -175,6 +183,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string $type
+     * @return void
      */
     public function removeType($type)
     {
@@ -200,6 +209,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param mixed[] $components
+     * @return void
      */
     public function setComponents(array $components)
     {
@@ -209,6 +219,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param mixed[] $components
+     * @return void
      */
     public function addComponents(array $components)
     {
@@ -240,6 +251,7 @@ class Autocomplete implements VariableAwareInterface
     /**
      * @param string $type
      * @param mixed  $value
+     * @return void
      */
     public function setComponent($type, $value)
     {
@@ -248,6 +260,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string $type
+     * @return void
      */
     public function removeComponent($type)
     {
@@ -272,6 +285,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string|null $value
+     * @return void
      */
     public function setValue($value = null)
     {
@@ -296,6 +310,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string[] $inputAttributes
+     * @return void
      */
     public function setInputAttributes(array $inputAttributes)
     {
@@ -305,6 +320,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string[] $inputAttributes
+     * @return void
      */
     public function addInputAttributes(array $inputAttributes)
     {
@@ -336,6 +352,7 @@ class Autocomplete implements VariableAwareInterface
     /**
      * @param string $name
      * @param string $value
+     * @return void
      */
     public function setInputAttribute($name, $value)
     {
@@ -344,6 +361,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string $name
+     * @return void
      */
     public function removeInputAttribute($name)
     {
@@ -368,6 +386,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string[] $libraries
+     * @return void
      */
     public function setLibraries(array $libraries)
     {
@@ -377,6 +396,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string[] $libraries
+     * @return void
      */
     public function addLibraries(array $libraries)
     {
@@ -397,6 +417,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string $library
+     * @return void
      */
     public function addLibrary($library)
     {
@@ -407,6 +428,7 @@ class Autocomplete implements VariableAwareInterface
 
     /**
      * @param string $library
+     * @return void
      */
     public function removeLibrary($library)
     {

--- a/src/Service/AbstractHttpService.php
+++ b/src/Service/AbstractHttpService.php
@@ -38,7 +38,9 @@ abstract class AbstractHttpService extends AbstractService
     {
         return $this->client;
     }
-
+    /**
+     * @return void
+     */
     public function setClient(HttpClient $client)
     {
         $this->client = $client;
@@ -51,7 +53,9 @@ abstract class AbstractHttpService extends AbstractService
     {
         return $this->messageFactory;
     }
-
+    /**
+     * @return void
+     */
     public function setMessageFactory(MessageFactory $messageFactory)
     {
         $this->messageFactory = $messageFactory;

--- a/src/Service/AbstractService.php
+++ b/src/Service/AbstractService.php
@@ -49,6 +49,7 @@ abstract class AbstractService
 
     /**
      * @param string $url
+     * @return void
      */
     public function setUrl($url)
     {
@@ -73,6 +74,7 @@ abstract class AbstractService
 
     /**
      * @param string|null $key
+     * @return void
      */
     public function setKey($key)
     {
@@ -97,6 +99,7 @@ abstract class AbstractService
 
     /**
      * @param ?BusinessAccount $businessAccount
+     * @return void
      */
     public function setBusinessAccount(?BusinessAccount $businessAccount = null)
     {

--- a/src/Service/Base/Geometry.php
+++ b/src/Service/Base/Geometry.php
@@ -47,7 +47,9 @@ class Geometry
     {
         return $this->location;
     }
-
+    /**
+     * @return void
+     */
     public function setLocation(Coordinate $location = null)
     {
         $this->location = $location;
@@ -71,6 +73,7 @@ class Geometry
 
     /**
      * @param string|null $locationType
+     * @return void
      */
     public function setLocationType($locationType = null)
     {
@@ -92,7 +95,9 @@ class Geometry
     {
         return $this->viewport;
     }
-
+    /**
+     * @return void
+     */
     public function setViewport(Bound $viewport = null)
     {
         $this->viewport = $viewport;
@@ -113,7 +118,9 @@ class Geometry
     {
         return $this->bound;
     }
-
+    /**
+     * @return void
+     */
     public function setBound(?Bound $bound = null)
     {
         $this->bound = $bound;

--- a/src/Service/Base/Location/AddressLocation.php
+++ b/src/Service/Base/Location/AddressLocation.php
@@ -39,6 +39,7 @@ class AddressLocation implements LocationInterface
 
     /**
      * @param string $address
+     * @return void
      */
     public function setAddress($address)
     {

--- a/src/Service/Base/Location/CoordinateLocation.php
+++ b/src/Service/Base/Location/CoordinateLocation.php
@@ -35,7 +35,9 @@ class CoordinateLocation implements LocationInterface
     {
         return $this->coordinate;
     }
-
+    /**
+     * @return void
+     */
     public function setCoordinate(Coordinate $coordinate)
     {
         $this->coordinate = $coordinate;

--- a/src/Service/Base/Location/EncodedPolylineLocation.php
+++ b/src/Service/Base/Location/EncodedPolylineLocation.php
@@ -39,6 +39,7 @@ class EncodedPolylineLocation implements LocationInterface
 
     /**
      * @param string $encodedPolyline
+     * @return void
      */
     public function setEncodedPolyline($encodedPolyline)
     {

--- a/src/Service/Base/Location/PlaceIdLocation.php
+++ b/src/Service/Base/Location/PlaceIdLocation.php
@@ -39,6 +39,7 @@ class PlaceIdLocation implements LocationInterface
 
     /**
      * @param string $placeId
+     * @return void
      */
     public function setPlaceId($placeId)
     {

--- a/src/Service/BusinessAccount.php
+++ b/src/Service/BusinessAccount.php
@@ -53,6 +53,7 @@ class BusinessAccount
 
     /**
      * @param string $clientId
+     * @return void
      */
     public function setClientId($clientId)
     {
@@ -69,6 +70,7 @@ class BusinessAccount
 
     /**
      * @param string $secret
+     * @return void
      */
     public function setSecret($secret)
     {
@@ -93,6 +95,7 @@ class BusinessAccount
 
     /**
      * @param string|null $channel
+     * @return void
      */
     public function setChannel($channel = null)
     {

--- a/src/Service/Direction/Request/DirectionRequest.php
+++ b/src/Service/Direction/Request/DirectionRequest.php
@@ -11,6 +11,7 @@
 
 namespace Ivory\GoogleMap\Service\Direction\Request;
 
+use DateTime;
 use Ivory\GoogleMap\Service\Base\Location\LocationInterface;
 
 /**
@@ -108,7 +109,9 @@ class DirectionRequest implements DirectionRequestInterface
     {
         return $this->origin;
     }
-
+    /**
+     * @return void
+     */
     public function setOrigin(LocationInterface $origin)
     {
         $this->origin = $origin;
@@ -121,7 +124,9 @@ class DirectionRequest implements DirectionRequestInterface
     {
         return $this->destination;
     }
-
+    /**
+     * @return void
+     */
     public function setDestination(LocationInterface $destination)
     {
         $this->destination = $destination;
@@ -142,7 +147,9 @@ class DirectionRequest implements DirectionRequestInterface
     {
         return $this->departureTime;
     }
-
+    /**
+     * @return void
+     */
     public function setDepartureTime(\DateTime $departureTime = null)
     {
         $this->departureTime = $departureTime;
@@ -163,7 +170,9 @@ class DirectionRequest implements DirectionRequestInterface
     {
         return $this->arrivalTime;
     }
-
+    /**
+     * @return void
+     */
     public function setArrivalTime(\DateTime $arrivalTime = null)
     {
         $this->arrivalTime = $arrivalTime;
@@ -187,6 +196,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param DirectionWaypoint[] $waypoints
+     * @return void
      */
     public function setWaypoints(array $waypoints)
     {
@@ -196,6 +206,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param DirectionWaypoint[] $waypoints
+     * @return void
      */
     public function addWaypoints(array $waypoints)
     {
@@ -211,14 +222,18 @@ class DirectionRequest implements DirectionRequestInterface
     {
         return in_array($waypoint, $this->waypoints, true);
     }
-
+    /**
+     * @return void
+     */
     public function addWaypoint(DirectionWaypoint $waypoint)
     {
         if (!$this->hasWaypoint($waypoint)) {
             $this->waypoints[] = $waypoint;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeWaypoint(DirectionWaypoint $waypoint)
     {
         unset($this->waypoints[array_search($waypoint, $this->waypoints, true)]);
@@ -243,6 +258,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param bool|null $optimizeWaypoints
+     * @return void
      */
     public function setOptimizeWaypoints($optimizeWaypoints = null)
     {
@@ -267,6 +283,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param string|null $travelMode
+     * @return void
      */
     public function setTravelMode($travelMode = null)
     {
@@ -291,6 +308,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param string|null $avoid
+     * @return void
      */
     public function setAvoid($avoid = null)
     {
@@ -315,6 +333,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param bool|null $provideRouteAlternatives
+     * @return void
      */
     public function setProvideRouteAlternatives($provideRouteAlternatives = null)
     {
@@ -339,6 +358,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param string|null $trafficModel
+     * @return void
      */
     public function setTrafficModel($trafficModel)
     {
@@ -363,6 +383,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param string[] $transitModes
+     * @return void
      */
     public function setTransitModes(array $transitModes)
     {
@@ -372,6 +393,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param string[] $transitModes
+     * @return void
      */
     public function addTransitModes(array $transitModes)
     {
@@ -392,6 +414,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param string $transitMode
+     * @return void
      */
     public function addTransitMode($transitMode)
     {
@@ -402,6 +425,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param string $transitMode
+     * @return void
      */
     public function removeTransitMode($transitMode)
     {
@@ -427,6 +451,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param string|null $transitRoutingPreference
+     * @return void
      */
     public function setTransitRoutingPreference($transitRoutingPreference)
     {
@@ -451,6 +476,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param string|null $region
+     * @return void
      */
     public function setRegion($region = null)
     {
@@ -475,6 +501,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param string|null $unitSystem
+     * @return void
      */
     public function setUnitSystem($unitSystem = null)
     {
@@ -499,6 +526,7 @@ class DirectionRequest implements DirectionRequestInterface
 
     /**
      * @param string|null $language
+     * @return void
      */
     public function setLanguage($language = null)
     {

--- a/src/Service/Direction/Request/DirectionWaypoint.php
+++ b/src/Service/Direction/Request/DirectionWaypoint.php
@@ -46,7 +46,9 @@ class DirectionWaypoint
     {
         return $this->location;
     }
-
+    /**
+     * @return void
+     */
     public function setLocation(LocationInterface $location)
     {
         $this->location = $location;
@@ -70,6 +72,7 @@ class DirectionWaypoint
 
     /**
      * @param bool|null $stopover
+     * @return void
      */
     public function setStopover($stopover = null)
     {

--- a/src/Service/Direction/Response/DirectionResponse.php
+++ b/src/Service/Direction/Response/DirectionResponse.php
@@ -114,7 +114,9 @@ class DirectionResponse
     {
         return !empty($this->geocodedWaypoints);
     }
-
+    /**
+     * @return DirectionGeocoded[]
+     */
     public function getGeocodedWaypoints(): array
     {
         return $this->geocodedWaypoints;

--- a/src/Service/Direction/Response/DirectionRoute.php
+++ b/src/Service/Direction/Response/DirectionRoute.php
@@ -173,7 +173,9 @@ class DirectionRoute
     {
         return !empty($this->warnings);
     }
-
+    /**
+     * @return string[]
+     */
     public function getWarnings(): array
     {
         return $this->warnings;

--- a/src/Service/Direction/Response/Transit/DirectionTransitAgency.php
+++ b/src/Service/Direction/Response/Transit/DirectionTransitAgency.php
@@ -49,6 +49,7 @@ class DirectionTransitAgency
 
     /**
      * @param string|null $name
+     * @return void
      */
     public function setName($name)
     {
@@ -73,6 +74,7 @@ class DirectionTransitAgency
 
     /**
      * @param string|null $phone
+     * @return void
      */
     public function setPhone($phone)
     {
@@ -97,6 +99,7 @@ class DirectionTransitAgency
 
     /**
      * @param string|null $url
+     * @return void
      */
     public function setUrl($url)
     {

--- a/src/Service/Direction/Response/Transit/DirectionTransitDetails.php
+++ b/src/Service/Direction/Response/Transit/DirectionTransitDetails.php
@@ -122,7 +122,9 @@ class DirectionTransitDetails
     {
         return null !== $this->headWay;
     }
-
+    /**
+     * @return string|int|null
+     */
     public function getHeadWay()
     {
         return $this->headWay;

--- a/src/Service/Direction/Response/Transit/DirectionTransitLine.php
+++ b/src/Service/Direction/Response/Transit/DirectionTransitLine.php
@@ -74,6 +74,7 @@ class DirectionTransitLine
 
     /**
      * @param string|null $name
+     * @return void
      */
     public function setName($name)
     {
@@ -98,6 +99,7 @@ class DirectionTransitLine
 
     /**
      * @param string|null $shortName
+     * @return void
      */
     public function setShortName($shortName)
     {
@@ -122,6 +124,7 @@ class DirectionTransitLine
 
     /**
      * @param string|null $color
+     * @return void
      */
     public function setColor($color)
     {
@@ -146,6 +149,7 @@ class DirectionTransitLine
 
     /**
      * @param string|null $url
+     * @return void
      */
     public function setUrl($url)
     {
@@ -170,6 +174,7 @@ class DirectionTransitLine
 
     /**
      * @param string|null $icon
+     * @return void
      */
     public function setIcon($icon)
     {
@@ -194,6 +199,7 @@ class DirectionTransitLine
 
     /**
      * @param string|null $textColor
+     * @return void
      */
     public function setTextColor($textColor)
     {
@@ -215,7 +221,9 @@ class DirectionTransitLine
     {
         return $this->vehicle;
     }
-
+    /**
+     * @return void
+     */
     public function setVehicle(DirectionTransitVehicle $vehicle = null)
     {
         $this->vehicle = $vehicle;
@@ -239,6 +247,7 @@ class DirectionTransitLine
 
     /**
      * @param DirectionTransitAgency[] $agencies
+     * @return void
      */
     public function setAgencies(array $agencies)
     {
@@ -248,6 +257,7 @@ class DirectionTransitLine
 
     /**
      * @param DirectionTransitAgency[] $agencies
+     * @return void
      */
     public function addAgencies(array $agencies)
     {
@@ -263,14 +273,18 @@ class DirectionTransitLine
     {
         return in_array($agency, $this->agencies, true);
     }
-
+    /**
+     * @return void
+     */
     public function addAgency(DirectionTransitAgency $agency)
     {
         if (!$this->hasAgency($agency)) {
             $this->agencies[] = $agency;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeAgency(DirectionTransitAgency $agency)
     {
         unset($this->agencies[array_search($agency, $this->agencies, true)]);

--- a/src/Service/Direction/Response/Transit/DirectionTransitStop.php
+++ b/src/Service/Direction/Response/Transit/DirectionTransitStop.php
@@ -46,6 +46,7 @@ class DirectionTransitStop
 
     /**
      * @param string|null $name
+     * @return void
      */
     public function setName($name)
     {
@@ -67,7 +68,9 @@ class DirectionTransitStop
     {
         return $this->location;
     }
-
+    /**
+     * @return void
+     */
     public function setLocation(Coordinate $location = null)
     {
         $this->location = $location;

--- a/src/Service/Direction/Response/Transit/DirectionTransitVehicle.php
+++ b/src/Service/Direction/Response/Transit/DirectionTransitVehicle.php
@@ -54,6 +54,7 @@ class DirectionTransitVehicle
 
     /**
      * @param string|null $name
+     * @return void
      */
     public function setName($name)
     {
@@ -78,6 +79,7 @@ class DirectionTransitVehicle
 
     /**
      * @param string|null $icon
+     * @return void
      */
     public function setIcon($icon)
     {
@@ -102,6 +104,7 @@ class DirectionTransitVehicle
 
     /**
      * @param string|null $type
+     * @return void
      */
     public function setType($type)
     {
@@ -126,6 +129,7 @@ class DirectionTransitVehicle
 
     /**
      * @param string|null $localIcon
+     * @return void
      */
     public function setLocalIcon($localIcon)
     {

--- a/src/Service/DistanceMatrix/Request/DistanceMatrixRequest.php
+++ b/src/Service/DistanceMatrix/Request/DistanceMatrixRequest.php
@@ -11,6 +11,7 @@
 
 namespace Ivory\GoogleMap\Service\DistanceMatrix\Request;
 
+use DateTime;
 use Ivory\GoogleMap\Service\Base\Location\EncodedPolylineLocation;
 use Ivory\GoogleMap\Service\Base\Location\LocationInterface;
 
@@ -109,6 +110,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param LocationInterface[] $origins
+     * @return void
      */
     public function setOrigins(array $origins)
     {
@@ -118,6 +120,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param LocationInterface[] $origins
+     * @return void
      */
     public function addOrigins(array $origins)
     {
@@ -133,14 +136,18 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
     {
         return in_array($origin, $this->origins, true);
     }
-
+    /**
+     * @return void
+     */
     public function addOrigin(LocationInterface $origin)
     {
         if (!$this->hasOrigin($origin)) {
             $this->origins[] = $origin;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeOrigin(LocationInterface $origin)
     {
         unset($this->origins[array_search($origin, $this->origins, true)]);
@@ -165,6 +172,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param LocationInterface[] $destinations
+     * @return void
      */
     public function setDestinations(array $destinations)
     {
@@ -174,6 +182,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param LocationInterface[] $destinations
+     * @return void
      */
     public function addDestinations(array $destinations)
     {
@@ -189,14 +198,18 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
     {
         return in_array($destination, $this->destinations, true);
     }
-
+    /**
+     * @return void
+     */
     public function addDestination(LocationInterface $destination)
     {
         if (!$this->hasDestination($destination)) {
             $this->destinations[] = $destination;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeDestination(LocationInterface $destination)
     {
         unset($this->destinations[array_search($destination, $this->destinations, true)]);
@@ -218,7 +231,9 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
     {
         return $this->departureTime;
     }
-
+    /**
+     * @return void
+     */
     public function setDepartureTime(\DateTime $departureTime = null)
     {
         $this->departureTime = $departureTime;
@@ -239,7 +254,9 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
     {
         return $this->arrivalTime;
     }
-
+    /**
+     * @return void
+     */
     public function setArrivalTime(\DateTime $arrivalTime = null)
     {
         $this->arrivalTime = $arrivalTime;
@@ -263,6 +280,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param string|null $travelMode
+     * @return void
      */
     public function setTravelMode($travelMode = null)
     {
@@ -287,6 +305,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param string|null $avoid
+     * @return void
      */
     public function setAvoid($avoid = null)
     {
@@ -311,6 +330,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param string|null $trafficModel
+     * @return void
      */
     public function setTrafficModel($trafficModel)
     {
@@ -335,6 +355,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param string[] $transitModes
+     * @return void
      */
     public function setTransitModes(array $transitModes)
     {
@@ -344,6 +365,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param string[] $transitModes
+     * @return void
      */
     public function addTransitModes(array $transitModes)
     {
@@ -364,6 +386,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param string $transitMode
+     * @return void
      */
     public function addTransitMode($transitMode)
     {
@@ -374,6 +397,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param string $transitMode
+     * @return void
      */
     public function removeTransitMode($transitMode)
     {
@@ -399,6 +423,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param string|null $transitRoutingPreference
+     * @return void
      */
     public function setTransitRoutingPreference($transitRoutingPreference)
     {
@@ -423,6 +448,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param string|null $region
+     * @return void
      */
     public function setRegion($region = null)
     {
@@ -447,6 +473,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param string|null $unitSystem
+     * @return void
      */
     public function setUnitSystem($unitSystem = null)
     {
@@ -471,6 +498,7 @@ class DistanceMatrixRequest implements DistanceMatrixRequestInterface
 
     /**
      * @param string|null $language
+     * @return void
      */
     public function setLanguage($language = null)
     {

--- a/src/Service/DistanceMatrix/Response/DistanceMatrixResponse.php
+++ b/src/Service/DistanceMatrix/Response/DistanceMatrixResponse.php
@@ -70,7 +70,9 @@ class DistanceMatrixResponse
     {
         return !empty($this->origins);
     }
-
+    /**
+     * @return string[]
+     */
     public function getOrigins(): array
     {
         return $this->origins;

--- a/src/Service/Elevation/Request/PathElevationRequest.php
+++ b/src/Service/Elevation/Request/PathElevationRequest.php
@@ -56,6 +56,7 @@ class PathElevationRequest implements ElevationRequestInterface
 
     /**
      * @param LocationInterface[] $paths
+     * @return void
      */
     public function setPaths(array $paths)
     {
@@ -65,6 +66,7 @@ class PathElevationRequest implements ElevationRequestInterface
 
     /**
      * @param LocationInterface[] $paths
+     * @return void
      */
     public function addPaths(array $paths)
     {
@@ -80,14 +82,18 @@ class PathElevationRequest implements ElevationRequestInterface
     {
         return in_array($path, $this->paths, true);
     }
-
+    /**
+     * @return void
+     */
     public function addPath(LocationInterface $path)
     {
         if (!$this->hasPath($path)) {
             $this->paths[] = $path;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removePath(LocationInterface $path)
     {
         unset($this->paths[array_search($path, $this->paths, true)]);
@@ -104,6 +110,7 @@ class PathElevationRequest implements ElevationRequestInterface
 
     /**
      * @param int $samples
+     * @return void
      */
     public function setSamples($samples)
     {

--- a/src/Service/Elevation/Request/PositionalElevationRequest.php
+++ b/src/Service/Elevation/Request/PositionalElevationRequest.php
@@ -49,6 +49,7 @@ class PositionalElevationRequest implements ElevationRequestInterface
 
     /**
      * @param LocationInterface[] $locations
+     * @return void
      */
     public function setLocations(array $locations)
     {
@@ -58,6 +59,7 @@ class PositionalElevationRequest implements ElevationRequestInterface
 
     /**
      * @param LocationInterface[] $locations
+     * @return void
      */
     public function addLocations(array $locations)
     {
@@ -73,14 +75,18 @@ class PositionalElevationRequest implements ElevationRequestInterface
     {
         return in_array($location, $this->locations, true);
     }
-
+    /**
+     * @return void
+     */
     public function addLocation(LocationInterface $location)
     {
         if (!$this->hasLocation($location)) {
             $this->locations[] = $location;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeLocation(LocationInterface $location)
     {
         unset($this->locations[array_search($location, $this->locations, true)]);

--- a/src/Service/Elevation/Response/ElevationResponse.php
+++ b/src/Service/Elevation/Response/ElevationResponse.php
@@ -51,6 +51,7 @@ class ElevationResponse
 
     /**
      * @param string|null $status
+     * @return void
      */
     public function setStatus($status)
     {
@@ -72,7 +73,9 @@ class ElevationResponse
     {
         return $this->request;
     }
-
+    /**
+     * @return void
+     */
     public function setRequest(ElevationRequestInterface $request = null)
     {
         $this->request = $request;
@@ -96,6 +99,7 @@ class ElevationResponse
 
     /**
      * @param ElevationResult[] $results
+     * @return void
      */
     public function setResults(array $results)
     {
@@ -105,6 +109,7 @@ class ElevationResponse
 
     /**
      * @param ElevationResult[] $results
+     * @return void
      */
     public function addResults(array $results)
     {
@@ -120,14 +125,18 @@ class ElevationResponse
     {
         return in_array($result, $this->results, true);
     }
-
+    /**
+     * @return void
+     */
     public function addResult(ElevationResult $result)
     {
         if (!$this->hasResult($result)) {
             $this->results[] = $result;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeResult(ElevationResult $result)
     {
         unset($this->results[array_search($result, $this->results, true)]);

--- a/src/Service/Elevation/Response/ElevationResult.php
+++ b/src/Service/Elevation/Response/ElevationResult.php
@@ -48,7 +48,9 @@ class ElevationResult
     {
         return $this->location;
     }
-
+    /**
+     * @return void
+     */
     public function setLocation(Coordinate $location = null)
     {
         $this->location = $location;
@@ -72,6 +74,7 @@ class ElevationResult
 
     /**
      * @param float|null $elevation
+     * @return void
      */
     public function setElevation($elevation)
     {
@@ -96,6 +99,7 @@ class ElevationResult
 
     /**
      * @param float|null $resolution
+     * @return void
      */
     public function setResolution($resolution)
     {

--- a/src/Service/Geocoder/Request/AbstractGeocoderRequest.php
+++ b/src/Service/Geocoder/Request/AbstractGeocoderRequest.php
@@ -43,6 +43,7 @@ abstract class AbstractGeocoderRequest implements GeocoderRequestInterface
 
     /**
      * @param string|null $language
+     * @return void
      */
     public function setLanguage($language = null)
     {

--- a/src/Service/Geocoder/Request/AbstractGeocoderReverseRequest.php
+++ b/src/Service/Geocoder/Request/AbstractGeocoderReverseRequest.php
@@ -46,6 +46,7 @@ abstract class AbstractGeocoderReverseRequest extends AbstractGeocoderRequest
 
     /**
      * @param string[] $resultTypes
+     * @return void
      */
     public function setResultTypes(array $resultTypes)
     {
@@ -55,6 +56,7 @@ abstract class AbstractGeocoderReverseRequest extends AbstractGeocoderRequest
 
     /**
      * @param string[] $resultTypes
+     * @return void
      */
     public function addResultTypes(array $resultTypes)
     {
@@ -75,6 +77,7 @@ abstract class AbstractGeocoderReverseRequest extends AbstractGeocoderRequest
 
     /**
      * @param string $resultType
+     * @return void
      */
     public function addResultType($resultType)
     {
@@ -85,6 +88,7 @@ abstract class AbstractGeocoderReverseRequest extends AbstractGeocoderRequest
 
     /**
      * @param string $resultType
+     * @return void
      */
     public function removeResultType($resultType)
     {
@@ -110,6 +114,7 @@ abstract class AbstractGeocoderReverseRequest extends AbstractGeocoderRequest
 
     /**
      * @param string[] $locationTypes
+     * @return void
      */
     public function setLocationTypes(array $locationTypes)
     {
@@ -119,6 +124,7 @@ abstract class AbstractGeocoderReverseRequest extends AbstractGeocoderRequest
 
     /**
      * @param string[] $locationTypes
+     * @return void
      */
     public function addLocationTypes(array $locationTypes)
     {
@@ -139,6 +145,7 @@ abstract class AbstractGeocoderReverseRequest extends AbstractGeocoderRequest
 
     /**
      * @param string $locationType
+     * @return void
      */
     public function addLocationType($locationType)
     {
@@ -149,6 +156,7 @@ abstract class AbstractGeocoderReverseRequest extends AbstractGeocoderRequest
 
     /**
      * @param string $locationType
+     * @return void
      */
     public function removeLocationType($locationType)
     {

--- a/src/Service/Geocoder/Request/GeocoderAddressRequest.php
+++ b/src/Service/Geocoder/Request/GeocoderAddressRequest.php
@@ -58,6 +58,7 @@ class GeocoderAddressRequest extends AbstractGeocoderRequest
 
     /**
      * @param string $address
+     * @return void
      */
     public function setAddress($address)
     {
@@ -82,6 +83,7 @@ class GeocoderAddressRequest extends AbstractGeocoderRequest
 
     /**
      * @param mixed[] $components
+     * @return void
      */
     public function setComponents(array $components)
     {
@@ -91,6 +93,7 @@ class GeocoderAddressRequest extends AbstractGeocoderRequest
 
     /**
      * @param mixed[] $components
+     * @return void
      */
     public function addComponents(array $components)
     {
@@ -122,6 +125,7 @@ class GeocoderAddressRequest extends AbstractGeocoderRequest
     /**
      * @param string $type
      * @param mixed  $value
+     * @return void
      */
     public function setComponent($type, $value)
     {
@@ -130,6 +134,7 @@ class GeocoderAddressRequest extends AbstractGeocoderRequest
 
     /**
      * @param string $type
+     * @return void
      */
     public function removeComponent($type)
     {
@@ -151,7 +156,9 @@ class GeocoderAddressRequest extends AbstractGeocoderRequest
     {
         return $this->bound;
     }
-
+    /**
+     * @return void
+     */
     public function setBound(?Bound $bound = null)
     {
         $this->bound = $bound;
@@ -175,6 +182,7 @@ class GeocoderAddressRequest extends AbstractGeocoderRequest
 
     /**
      * @param string|null $region
+     * @return void
      */
     public function setRegion($region = null)
     {

--- a/src/Service/Geocoder/Request/GeocoderCoordinateRequest.php
+++ b/src/Service/Geocoder/Request/GeocoderCoordinateRequest.php
@@ -37,7 +37,9 @@ class GeocoderCoordinateRequest extends AbstractGeocoderReverseRequest
     {
         return $this->coordinate;
     }
-
+    /**
+     * @return void
+     */
     public function setCoordinate(Coordinate $coordinate)
     {
         $this->coordinate = $coordinate;

--- a/src/Service/Geocoder/Request/GeocoderPlaceIdRequest.php
+++ b/src/Service/Geocoder/Request/GeocoderPlaceIdRequest.php
@@ -41,6 +41,7 @@ class GeocoderPlaceIdRequest extends AbstractGeocoderReverseRequest
 
     /**
      * @param string $placeId
+     * @return void
      */
     public function setPlaceId($placeId)
     {

--- a/src/Service/Geocoder/Response/GeocoderResult.php
+++ b/src/Service/Geocoder/Response/GeocoderResult.php
@@ -138,7 +138,9 @@ class GeocoderResult
     {
         return !empty($this->postcodeLocalities);
     }
-
+    /**
+     * @return string[]
+     */
     public function getPostcodeLocalities(): array
     {
         return $this->postcodeLocalities;

--- a/src/Service/Place/Autocomplete/Request/AbstractPlaceAutocompleteRequest.php
+++ b/src/Service/Place/Autocomplete/Request/AbstractPlaceAutocompleteRequest.php
@@ -61,6 +61,7 @@ abstract class AbstractPlaceAutocompleteRequest implements PlaceAutocompleteRequ
 
     /**
      * @param string $input
+     * @return void
      */
     public function setInput($input)
     {
@@ -85,6 +86,7 @@ abstract class AbstractPlaceAutocompleteRequest implements PlaceAutocompleteRequ
 
     /**
      * @param int|null $offset
+     * @return void
      */
     public function setOffset($offset)
     {
@@ -106,7 +108,9 @@ abstract class AbstractPlaceAutocompleteRequest implements PlaceAutocompleteRequ
     {
         return $this->location;
     }
-
+    /**
+     * @return void
+     */
     public function setLocation(Coordinate $location = null)
     {
         $this->location = $location;
@@ -130,6 +134,7 @@ abstract class AbstractPlaceAutocompleteRequest implements PlaceAutocompleteRequ
 
     /**
      * @param float|null $radius
+     * @return void
      */
     public function setRadius($radius)
     {
@@ -154,6 +159,7 @@ abstract class AbstractPlaceAutocompleteRequest implements PlaceAutocompleteRequ
 
     /**
      * @param string|null $language
+     * @return void
      */
     public function setLanguage($language)
     {

--- a/src/Service/Place/Autocomplete/Request/PlaceAutocompleteRequest.php
+++ b/src/Service/Place/Autocomplete/Request/PlaceAutocompleteRequest.php
@@ -44,6 +44,7 @@ class PlaceAutocompleteRequest extends AbstractPlaceAutocompleteRequest
 
     /**
      * @param string[] $types
+     * @return void
      */
     public function setTypes(array $types)
     {
@@ -53,6 +54,7 @@ class PlaceAutocompleteRequest extends AbstractPlaceAutocompleteRequest
 
     /**
      * @param string[] $types
+     * @return void
      */
     public function addTypes(array $types)
     {
@@ -73,6 +75,7 @@ class PlaceAutocompleteRequest extends AbstractPlaceAutocompleteRequest
 
     /**
      * @param string $type
+     * @return void
      */
     public function addType($type)
     {
@@ -83,6 +86,7 @@ class PlaceAutocompleteRequest extends AbstractPlaceAutocompleteRequest
 
     /**
      * @param string $type
+     * @return void
      */
     public function removeType($type)
     {
@@ -108,6 +112,7 @@ class PlaceAutocompleteRequest extends AbstractPlaceAutocompleteRequest
 
     /**
      * @param string[] $components
+     * @return void
      */
     public function setComponents(array $components)
     {
@@ -117,6 +122,7 @@ class PlaceAutocompleteRequest extends AbstractPlaceAutocompleteRequest
 
     /**
      * @param string[] $components
+     * @return void
      */
     public function addComponents(array $components)
     {
@@ -148,6 +154,7 @@ class PlaceAutocompleteRequest extends AbstractPlaceAutocompleteRequest
     /**
      * @param string $type
      * @param string $value
+     * @return void
      */
     public function setComponent($type, $value)
     {
@@ -156,6 +163,7 @@ class PlaceAutocompleteRequest extends AbstractPlaceAutocompleteRequest
 
     /**
      * @param string $type
+     * @return void
      */
     public function removeComponent($type)
     {

--- a/src/Service/Place/Base/AlternatePlaceId.php
+++ b/src/Service/Place/Base/AlternatePlaceId.php
@@ -44,6 +44,7 @@ class AlternatePlaceId
 
     /**
      * @param string|null $placeId
+     * @return void
      */
     public function setPlaceId($placeId)
     {
@@ -68,6 +69,7 @@ class AlternatePlaceId
 
     /**
      * @param string|null $scope
+     * @return void
      */
     public function setScope($scope)
     {

--- a/src/Service/Place/Base/AspectRating.php
+++ b/src/Service/Place/Base/AspectRating.php
@@ -44,6 +44,7 @@ class AspectRating
 
     /**
      * @param string|null $type
+     * @return void
      */
     public function setType($type)
     {
@@ -68,6 +69,7 @@ class AspectRating
 
     /**
      * @param float|null $rating
+     * @return void
      */
     public function setRating($rating)
     {

--- a/src/Service/Place/Detail/Request/PlaceDetailRequest.php
+++ b/src/Service/Place/Detail/Request/PlaceDetailRequest.php
@@ -44,6 +44,7 @@ class PlaceDetailRequest implements PlaceDetailRequestInterface
 
     /**
      * @param string $placeId
+     * @return void
      */
     public function setPlaceId($placeId)
     {
@@ -68,6 +69,7 @@ class PlaceDetailRequest implements PlaceDetailRequestInterface
 
     /**
      * @param string|null $language
+     * @return void
      */
     public function setLanguage($language)
     {

--- a/src/Service/Place/Photo/Request/PlacePhotoRequest.php
+++ b/src/Service/Place/Photo/Request/PlacePhotoRequest.php
@@ -49,6 +49,7 @@ class PlacePhotoRequest implements PlacePhotoRequestInterface
 
     /**
      * @param string $reference
+     * @return void
      */
     public function setReference($reference)
     {
@@ -73,6 +74,7 @@ class PlacePhotoRequest implements PlacePhotoRequestInterface
 
     /**
      * @param int|null $maxWidth
+     * @return void
      */
     public function setMaxWidth($maxWidth)
     {
@@ -97,6 +99,7 @@ class PlacePhotoRequest implements PlacePhotoRequestInterface
 
     /**
      * @param int|null $maxHeight
+     * @return void
      */
     public function setMaxHeight($maxHeight)
     {

--- a/src/Service/Place/Search/Request/AbstractPlaceSearchRequest.php
+++ b/src/Service/Place/Search/Request/AbstractPlaceSearchRequest.php
@@ -68,7 +68,9 @@ abstract class AbstractPlaceSearchRequest implements PlaceSearchRequestInterface
     {
         return $this->location;
     }
-
+    /**
+     * @return void
+     */
     public function setLocation(Coordinate $location = null)
     {
         $this->location = $location;
@@ -92,6 +94,7 @@ abstract class AbstractPlaceSearchRequest implements PlaceSearchRequestInterface
 
     /**
      * @param float $radius
+     * @return void
      */
     public function setRadius($radius)
     {
@@ -116,6 +119,7 @@ abstract class AbstractPlaceSearchRequest implements PlaceSearchRequestInterface
 
     /**
      * @param int|null $minPrice
+     * @return void
      */
     public function setMinPrice($minPrice)
     {
@@ -140,6 +144,7 @@ abstract class AbstractPlaceSearchRequest implements PlaceSearchRequestInterface
 
     /**
      * @param int|null $maxPrice
+     * @return void
      */
     public function setMaxPrice($maxPrice)
     {
@@ -164,6 +169,7 @@ abstract class AbstractPlaceSearchRequest implements PlaceSearchRequestInterface
 
     /**
      * @param bool|null $openNow
+     * @return void
      */
     public function setOpenNow($openNow)
     {
@@ -188,6 +194,7 @@ abstract class AbstractPlaceSearchRequest implements PlaceSearchRequestInterface
 
     /**
      * @param string|null $type
+     * @return void
      */
     public function setType($type)
     {
@@ -212,6 +219,7 @@ abstract class AbstractPlaceSearchRequest implements PlaceSearchRequestInterface
 
     /**
      * @param string|null $language
+     * @return void
      */
     public function setLanguage($language)
     {

--- a/src/Service/Place/Search/Request/AbstractTextualPlaceSearchRequest.php
+++ b/src/Service/Place/Search/Request/AbstractTextualPlaceSearchRequest.php
@@ -39,6 +39,7 @@ abstract class AbstractTextualPlaceSearchRequest extends AbstractPlaceSearchRequ
 
     /**
      * @param string|null $keyword
+     * @return void
      */
     public function setKeyword($keyword)
     {

--- a/src/Service/Place/Search/Request/NearbyPlaceSearchRequest.php
+++ b/src/Service/Place/Search/Request/NearbyPlaceSearchRequest.php
@@ -44,6 +44,7 @@ class NearbyPlaceSearchRequest extends AbstractTextualPlaceSearchRequest
 
     /**
      * @param string $rankBy
+     * @return void
      */
     public function setRankBy($rankBy)
     {

--- a/src/Service/Place/Search/Request/PageTokenPlaceSearchRequest.php
+++ b/src/Service/Place/Search/Request/PageTokenPlaceSearchRequest.php
@@ -35,7 +35,9 @@ class PageTokenPlaceSearchRequest implements PlaceSearchRequestInterface
     {
         return $this->response;
     }
-
+    /**
+     * @return void
+     */
     public function setResponse(PlaceSearchResponse $response)
     {
         $this->response = $response;

--- a/src/Service/Place/Search/Request/TextPlaceSearchRequest.php
+++ b/src/Service/Place/Search/Request/TextPlaceSearchRequest.php
@@ -39,6 +39,7 @@ class TextPlaceSearchRequest extends AbstractPlaceSearchRequest
 
     /**
      * @param string $query
+     * @return void
      */
     public function setQuery($query)
     {

--- a/src/Service/Place/Search/Response/PlaceSearchResponse.php
+++ b/src/Service/Place/Search/Response/PlaceSearchResponse.php
@@ -62,6 +62,7 @@ class PlaceSearchResponse
 
     /**
      * @param string|null $status
+     * @return void
      */
     public function setStatus($status)
     {
@@ -83,7 +84,9 @@ class PlaceSearchResponse
     {
         return $this->request;
     }
-
+    /**
+     * @return void
+     */
     public function setRequest(PlaceSearchRequestInterface $request = null)
     {
         $this->request = $request;
@@ -107,6 +110,7 @@ class PlaceSearchResponse
 
     /**
      * @param Place[] $results
+     * @return void
      */
     public function setResults(array $results)
     {
@@ -116,6 +120,7 @@ class PlaceSearchResponse
 
     /**
      * @param Place[] $results
+     * @return void
      */
     public function addResults(array $results)
     {
@@ -131,14 +136,18 @@ class PlaceSearchResponse
     {
         return in_array($result, $this->results, true);
     }
-
+    /**
+     * @return void
+     */
     public function addResult(Place $result)
     {
         if (!$this->hasResult($result)) {
             $this->results[] = $result;
         }
     }
-
+    /**
+     * @return void
+     */
     public function removeResult(Place $result)
     {
         unset($this->results[array_search($result, $this->results, true)]);
@@ -163,6 +172,7 @@ class PlaceSearchResponse
 
     /**
      * @param string[] $htmlAttributions
+     * @return void
      */
     public function setHtmlAttributions(array $htmlAttributions)
     {
@@ -172,6 +182,7 @@ class PlaceSearchResponse
 
     /**
      * @param string[] $htmlAttributions
+     * @return void
      */
     public function addHtmlAttributions(array $htmlAttributions)
     {
@@ -192,6 +203,7 @@ class PlaceSearchResponse
 
     /**
      * @param string $htmlAttribution
+     * @return void
      */
     public function addHtmlAttribution($htmlAttribution)
     {
@@ -202,6 +214,7 @@ class PlaceSearchResponse
 
     /**
      * @param string $htmlAttribution
+     * @return void
      */
     public function removeHtmlAttribution($htmlAttribution)
     {
@@ -227,6 +240,7 @@ class PlaceSearchResponse
 
     /**
      * @param string|null $nextPageToken
+     * @return void
      */
     public function setNextPageToken($nextPageToken)
     {

--- a/src/Service/Serializer/GoogleDateTimeNormalizer.php
+++ b/src/Service/Serializer/GoogleDateTimeNormalizer.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Ivory\GoogleMap\Service\Serializer;
 
+use ArrayObject;
+use DateTimeZone;
 use Symfony\Component\PropertyInfo\Type;
 use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 use Symfony\Component\Serializer\Exception\NotNormalizableValueException;

--- a/src/Service/TimeZone/Request/TimeZoneRequest.php
+++ b/src/Service/TimeZone/Request/TimeZoneRequest.php
@@ -11,6 +11,7 @@
 
 namespace Ivory\GoogleMap\Service\TimeZone\Request;
 
+use DateTime;
 use Ivory\GoogleMap\Base\Coordinate;
 
 /**
@@ -46,7 +47,9 @@ class TimeZoneRequest implements TimeZoneRequestInterface
     {
         return $this->location;
     }
-
+    /**
+     * @return void
+     */
     public function setLocation(Coordinate $location)
     {
         $this->location = $location;
@@ -59,7 +62,9 @@ class TimeZoneRequest implements TimeZoneRequestInterface
     {
         return $this->date;
     }
-
+    /**
+     * @return void
+     */
     public function setDate(\DateTime $date)
     {
         $this->date = $date;
@@ -83,6 +88,7 @@ class TimeZoneRequest implements TimeZoneRequestInterface
 
     /**
      * @param string|null $language
+     * @return void
      */
     public function setLanguage($language)
     {

--- a/src/Service/TimeZone/Response/TimeZoneResponse.php
+++ b/src/Service/TimeZone/Response/TimeZoneResponse.php
@@ -66,6 +66,7 @@ class TimeZoneResponse
 
     /**
      * @param string|null $status
+     * @return void
      */
     public function setStatus($status)
     {
@@ -87,7 +88,9 @@ class TimeZoneResponse
     {
         return $this->request;
     }
-
+    /**
+     * @return void
+     */
     public function setRequest(TimeZoneRequestInterface $request = null)
     {
         $this->request = $request;
@@ -111,6 +114,7 @@ class TimeZoneResponse
 
     /**
      * @param int|null $dstOffset
+     * @return void
      */
     public function setDstOffset($dstOffset)
     {
@@ -135,6 +139,7 @@ class TimeZoneResponse
 
     /**
      * @param int|null $rawOffset
+     * @return void
      */
     public function setRawOffset($rawOffset)
     {
@@ -159,6 +164,7 @@ class TimeZoneResponse
 
     /**
      * @param string|null $timeZoneId
+     * @return void
      */
     public function setTimeZoneId($timeZoneId)
     {
@@ -183,6 +189,7 @@ class TimeZoneResponse
 
     /**
      * @param string|null $timeZoneName
+     * @return void
      */
     public function setTimeZoneName($timeZoneName)
     {

--- a/src/Utility/OptionsAwareInterface.php
+++ b/src/Utility/OptionsAwareInterface.php
@@ -28,11 +28,13 @@ interface OptionsAwareInterface
 
     /**
      * @param mixed[] $options
+     * @return void
      */
     public function setOptions(array $options);
 
     /**
      * @param mixed[] $options
+     * @return void
      */
     public function addOptions(array $options);
 
@@ -53,11 +55,13 @@ interface OptionsAwareInterface
     /**
      * @param string $option
      * @param mixed  $value
+     * @return void
      */
     public function setOption($option, $value);
 
     /**
      * @param string $option
+     * @return void
      */
     public function removeOption($option);
 }

--- a/src/Utility/OptionsAwareTrait.php
+++ b/src/Utility/OptionsAwareTrait.php
@@ -39,6 +39,7 @@ trait OptionsAwareTrait
 
     /**
      * @param mixed[] $options
+     * @return void
      */
     public function setOptions(array $options)
     {
@@ -48,6 +49,7 @@ trait OptionsAwareTrait
 
     /**
      * @param mixed[] $options
+     * @return void
      */
     public function addOptions(array $options)
     {
@@ -79,6 +81,7 @@ trait OptionsAwareTrait
     /**
      * @param string $option
      * @param mixed  $value
+     * @return void
      */
     public function setOption($option, $value)
     {
@@ -87,6 +90,7 @@ trait OptionsAwareTrait
 
     /**
      * @param string $option
+     * @return void
      */
     public function removeOption($option)
     {

--- a/src/Utility/StaticOptionsAwareInterface.php
+++ b/src/Utility/StaticOptionsAwareInterface.php
@@ -28,11 +28,13 @@ interface StaticOptionsAwareInterface
 
     /**
      * @param mixed[] $options
+     * @return void
      */
     public function setStaticOptions(array $options);
 
     /**
      * @param mixed[] $options
+     * @return void
      */
     public function addStaticOptions(array $options);
 
@@ -53,11 +55,13 @@ interface StaticOptionsAwareInterface
     /**
      * @param string $option
      * @param mixed  $value
+     * @return void
      */
     public function setStaticOption($option, $value);
 
     /**
      * @param string $option
+     * @return void
      */
     public function removeStaticOption($option);
 }

--- a/src/Utility/StaticOptionsAwareTrait.php
+++ b/src/Utility/StaticOptionsAwareTrait.php
@@ -39,6 +39,7 @@ trait StaticOptionsAwareTrait
 
     /**
      * @param mixed[] $options
+     * @return void
      */
     public function setStaticOptions(array $options)
     {
@@ -48,6 +49,7 @@ trait StaticOptionsAwareTrait
 
     /**
      * @param mixed[] $options
+     * @return void
      */
     public function addStaticOptions(array $options)
     {
@@ -79,6 +81,7 @@ trait StaticOptionsAwareTrait
     /**
      * @param string $option
      * @param mixed  $value
+     * @return void
      */
     public function setStaticOption($option, $value)
     {
@@ -87,6 +90,7 @@ trait StaticOptionsAwareTrait
 
     /**
      * @param string $option
+     * @return void
      */
     public function removeStaticOption($option)
     {

--- a/src/Utility/VariableAwareInterface.php
+++ b/src/Utility/VariableAwareInterface.php
@@ -23,6 +23,7 @@ interface VariableAwareInterface
 
     /**
      * @param string $variable
+     * @return void
      */
     public function setVariable($variable);
 }

--- a/src/Utility/VariableAwareTrait.php
+++ b/src/Utility/VariableAwareTrait.php
@@ -36,6 +36,7 @@ trait VariableAwareTrait
 
     /**
      * @param string $variable
+     * @return void
      */
     public function setVariable($variable)
     {


### PR DESCRIPTION
Hello. Thanks you for your work )) after upgrade my php, i started get messages type deprecated. Exsample: 
Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "Ivory\GoogleMap\Helper\Subscriber\AbstractDelegateSubscriber" now to avoid errors or add an explicit @return annotation to suppress this message. 
In this pr  i added  return annotation  in phpdoc for fix this messages.