### PR TITLE
Replaced php-http/message-factory with nyholm/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "symfony/serializer": "^6.4 || ^7.0",
         "symfony/property-access": "^6.4 || ^7.0",
         "phpdocumentor/reflection-docblock": "^5.3",
-        "php-http/message-factory": "^1.1"
+        "nyholm/psr7": "^1.8"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.49",

--- a/src/Service/AbstractHttpService.php
+++ b/src/Service/AbstractHttpService.php
@@ -12,7 +12,7 @@
 namespace Ivory\GoogleMap\Service;
 
 use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Message\RequestInterface as PsrRequestInterface;
 
 /**
@@ -21,9 +21,9 @@ use Psr\Http\Message\RequestInterface as PsrRequestInterface;
 abstract class AbstractHttpService extends AbstractService
 {
     private HttpClient $client;
-    private MessageFactory $messageFactory;
+    private Psr17Factory $messageFactory;
 
-    public function __construct(string $url, HttpClient $client, MessageFactory $messageFactory)
+    public function __construct(string $url, HttpClient $client, Psr17Factory $messageFactory)
     {
         parent::__construct($url);
 
@@ -47,7 +47,7 @@ abstract class AbstractHttpService extends AbstractService
     }
 
     /**
-     * @return MessageFactory
+     * @return Psr17Factory
      */
     public function getMessageFactory()
     {
@@ -56,7 +56,7 @@ abstract class AbstractHttpService extends AbstractService
     /**
      * @return void
      */
-    public function setMessageFactory(MessageFactory $messageFactory)
+    public function setMessageFactory(Psr17Factory $messageFactory)
     {
         $this->messageFactory = $messageFactory;
     }

--- a/src/Service/AbstractSerializableService.php
+++ b/src/Service/AbstractSerializableService.php
@@ -12,8 +12,8 @@
 namespace Ivory\GoogleMap\Service;
 
 use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Component\Serializer\SerializerInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -30,7 +30,7 @@ abstract class AbstractSerializableService extends AbstractHttpService
     public function __construct(
         string $url,
         HttpClient $client,
-        MessageFactory $messageFactory,
+        Psr17Factory $messageFactory,
         ?SerializerInterface $serializer = null
     ) {
         parent::__construct($url, $client, $messageFactory);

--- a/src/Service/Direction/DirectionService.php
+++ b/src/Service/Direction/DirectionService.php
@@ -12,10 +12,10 @@
 namespace Ivory\GoogleMap\Service\Direction;
 
 use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\Direction\Request\DirectionRequestInterface;
 use Ivory\GoogleMap\Service\Direction\Response\DirectionResponse;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Psr\Http\Client\ClientExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
@@ -26,7 +26,7 @@ class DirectionService extends AbstractSerializableService
 {
     public function __construct(
         HttpClient $client,
-        MessageFactory $messageFactory,
+        Psr17Factory $messageFactory,
         ?SerializerInterface $serializer = null
     ) {
         parent::__construct('https://maps.googleapis.com/maps/api/directions', $client, $messageFactory, $serializer);

--- a/src/Service/DistanceMatrix/DistanceMatrixService.php
+++ b/src/Service/DistanceMatrix/DistanceMatrixService.php
@@ -12,10 +12,10 @@
 namespace Ivory\GoogleMap\Service\DistanceMatrix;
 
 use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\DistanceMatrix\Request\DistanceMatrixRequestInterface;
 use Ivory\GoogleMap\Service\DistanceMatrix\Response\DistanceMatrixResponse;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -25,7 +25,7 @@ class DistanceMatrixService extends AbstractSerializableService
 {
     public function __construct(
         HttpClient $client,
-        MessageFactory $messageFactory,
+        Psr17Factory $messageFactory,
         ?SerializerInterface $serializer = null
     ) {
         parent::__construct(

--- a/src/Service/Elevation/ElevationService.php
+++ b/src/Service/Elevation/ElevationService.php
@@ -12,10 +12,10 @@
 namespace Ivory\GoogleMap\Service\Elevation;
 
 use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\Elevation\Request\ElevationRequestInterface;
 use Ivory\GoogleMap\Service\Elevation\Response\ElevationResponse;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -25,7 +25,7 @@ class ElevationService extends AbstractSerializableService
 {
     public function __construct(
         HttpClient $client,
-        MessageFactory $messageFactory,
+        Psr17Factory $messageFactory,
         ?SerializerInterface $serializer = null
     ) {
         parent::__construct('https://maps.googleapis.com/maps/api/elevation', $client, $messageFactory, $serializer);

--- a/src/Service/Geocoder/GeocoderService.php
+++ b/src/Service/Geocoder/GeocoderService.php
@@ -12,10 +12,10 @@
 namespace Ivory\GoogleMap\Service\Geocoder;
 
 use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\Geocoder\Request\GeocoderRequestInterface;
 use Ivory\GoogleMap\Service\Geocoder\Response\GeocoderResponse;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -25,7 +25,7 @@ class GeocoderService extends AbstractSerializableService
 {
     public function __construct(
         HttpClient $client,
-        MessageFactory $messageFactory,
+        Psr17Factory $messageFactory,
         ?SerializerInterface $serializer = null
     ) {
         parent::__construct(

--- a/src/Service/Place/AbstractPlaceSerializableService.php
+++ b/src/Service/Place/AbstractPlaceSerializableService.php
@@ -12,8 +12,8 @@
 namespace Ivory\GoogleMap\Service\Place;
 
 use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -26,7 +26,7 @@ abstract class AbstractPlaceSerializableService extends AbstractSerializableServ
      */
     public function __construct(
         HttpClient $client,
-        MessageFactory $messageFactory,
+        Psr17Factory $messageFactory,
         ?SerializerInterface $serializer = null,
         $context = null
     ) {

--- a/src/Service/Place/Detail/PlaceDetailService.php
+++ b/src/Service/Place/Detail/PlaceDetailService.php
@@ -12,10 +12,10 @@
 namespace Ivory\GoogleMap\Service\Place\Detail;
 
 use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\Place\Detail\Request\PlaceDetailRequestInterface;
 use Ivory\GoogleMap\Service\Place\Detail\Response\PlaceDetailResponse;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -25,7 +25,7 @@ class PlaceDetailService extends AbstractSerializableService
 {
     public function __construct(
         HttpClient $client,
-        MessageFactory $messageFactory,
+        Psr17Factory $messageFactory,
         ?SerializerInterface $serializer = null
     ) {
         parent::__construct(

--- a/src/Service/TimeZone/TimeZoneService.php
+++ b/src/Service/TimeZone/TimeZoneService.php
@@ -12,10 +12,10 @@
 namespace Ivory\GoogleMap\Service\TimeZone;
 
 use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\TimeZone\Request\TimeZoneRequestInterface;
 use Ivory\GoogleMap\Service\TimeZone\Response\TimeZoneResponse;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -25,7 +25,7 @@ class TimeZoneService extends AbstractSerializableService
 {
     public function __construct(
         HttpClient $client,
-        MessageFactory $messageFactory,
+        Psr17Factory $messageFactory,
         ?SerializerInterface $serializer = null
     ) {
         parent::__construct('https://maps.googleapis.com/maps/api/timezone', $client, $messageFactory, $serializer);

--- a/tests/Service/AbstractFunctionalService.php
+++ b/tests/Service/AbstractFunctionalService.php
@@ -17,10 +17,10 @@ use Http\Client\Common\Plugin\HistoryPlugin;
 use Http\Client\Common\Plugin\RetryPlugin;
 use Http\Client\Common\PluginClient;
 use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Ivory\GoogleMap\Service\Plugin\ErrorPlugin;
 use Ivory\Tests\GoogleMap\Service\Utility\Journal;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
 use Psr\Http\Message\RequestInterface;
@@ -42,7 +42,7 @@ abstract class AbstractFunctionalService extends TestCase
     protected $client;
 
     /**
-     * @var MessageFactory
+     * @var Psr17Factory
      */
     protected $messageFactory;
 

--- a/tests/Service/AbstractUnitService.php
+++ b/tests/Service/AbstractUnitService.php
@@ -14,6 +14,7 @@ namespace Ivory\Tests\GoogleMap\Service;
 use Http\Client\HttpClient;
 use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\BusinessAccount;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
@@ -32,7 +33,7 @@ abstract class AbstractUnitService extends TestCase
     protected $client;
 
     /**
-     * @var MessageFactory|MockObject
+     * @var Psr17Factory|MockObject
      */
     protected $messageFactory;
 
@@ -60,11 +61,11 @@ abstract class AbstractUnitService extends TestCase
     }
 
     /**
-     * @return MockObject|MessageFactory
+     * @return MockObject|Psr17Factory
      */
     protected function createMessageFactoryMock()
     {
-        return $this->createMock(MessageFactory::class);
+        return $this->createMock(Psr17Factory::class);
     }
 
     /**

--- a/tests/Service/HttpServiceTest.php
+++ b/tests/Service/HttpServiceTest.php
@@ -12,9 +12,9 @@
 namespace Ivory\Tests\GoogleMap\Service;
 
 use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractHttpService;
 use Ivory\GoogleMap\Service\AbstractService;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -39,7 +39,7 @@ class HttpServiceTest extends TestCase
     private $client;
 
     /**
-     * @var MessageFactory|MockObject
+     * @var Psr17Factory|MockObject
      */
     private $messageFactory;
 
@@ -88,10 +88,10 @@ class HttpServiceTest extends TestCase
     }
 
     /**
-     * @return MockObject|MessageFactory
+     * @return MockObject|Psr17Factory
      */
     private function createMessageFactoryMock()
     {
-        return $this->createMock(MessageFactory::class);
+        return $this->createMock(Psr17Factory::class);
     }
 }

--- a/tests/Service/SerializableServiceTest.php
+++ b/tests/Service/SerializableServiceTest.php
@@ -16,6 +16,7 @@ use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractHttpService;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\BusinessAccount;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -41,7 +42,7 @@ class SerializableServiceTest extends TestCase
     private $client;
 
     /**
-     * @var MessageFactory|MockObject
+     * @var Psr17Factory|MockObject
      */
     private $messageFactory;
 
@@ -151,11 +152,11 @@ class SerializableServiceTest extends TestCase
     }
 
     /**
-     * @return MockObject|MessageFactory
+     * @return MockObject|Psr17Factory
      */
     private function createMessageFactoryMock()
     {
-        return $this->createMock(MessageFactory::class);
+        return $this->createMock(Psr17Factory::class);
     }
 
     /**


### PR DESCRIPTION
Fixes the `Package php-http/message-factory is abandoned, you should avoid using it. Use psr/http-factory instead.` message. 

Directly switching to `psr/http-factory`, results in quite some tests to be refactored, as the (deprecated) `\Http\Message\MessageFactory` was an interface for multiple interfaces. By using the `nyholm/psr7`, we can use the `\Nyholm\Psr7\Factory\Psr17Factory` as a direct drop-in replacement.

Probably this means a bump to a new major version to remain backwards compatible as users could be using the `\Http\Message\MessageFactory` directly?

Otherwise the upgrade path is as simple as the changes in this PR:
- Remove `php-http/message-factory`
- Require `nyholm/psr7`
- Replace `Http\Message\MessageFactory` with `Nyholm\Psr7\Factory\Psr17Factory`

I hope I don't miss something obvious, as it's almost to good to be true to still have all tests pass.

When approved/merged I'll take a look at updating the `ivory-google-map-bundle` too.