### PR TITLE
Replaced php-http/message-factory with psr/http-factory and psr/http-client

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,24 +11,25 @@ jobs:
     tests:
         runs-on: ubuntu-latest
 
-        name: PHP ${{ matrix.php }} - ${{ matrix.symfony-version }} - ${{ matrix.stability }}
+        name: PHP ${{ matrix.php }} - ${{ matrix.symfony }} - ${{ matrix.deps }}
 
         strategy:
             fail-fast: false
             matrix:
-                php: [8.2, 8.3, 8.4]
-                stability: [ prefer-stable ]
-                symfony-version: [ '6.4', '7.3' ]
+                php: [8.2, 8.3, 8.4, 8.5]
+                deps: [ locked ]
+                symfony: [ '6.4.*', '7.3.*' ]
                 include:
-                  - symfony-version: 6.4
-                    php: '8.1'
-                    stability: prefer-lowest
-                  - symfony-version: 6.4
-                    php: '8.1'
-                    stability: prefer-stable
+                    - symfony: '6.4.*'
+                      php: '8.1'
+                      deps: lowest
+                    - symfony: '7.4.*'
+                      php: '8.5'
+                      deps: highest
 
         env:
             APP_ENV: test
+            SYMFONY_REQUIRE: ${{ matrix.symfony }}
 
         steps:
             -
@@ -39,32 +40,22 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: "${{ matrix.php }}"
+                    ini-values: zend.exception_ignore_args=false
                     extensions: intl
-                    tools: symfony
+                    tools: symfony, flex
                     coverage: none
 
             -
-                name: Get Composer cache directory
-                id: composer-cache
-                run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+                name: Configure composer
+                if: "${{ matrix.deps == 'highest' }}"
+                run: composer config minimum-stability dev
 
             -
-                name: Cache Composer
-                uses: actions/cache@v4
+                name: Composer install
+                uses: ramsey/composer-install@v3
                 with:
-                    path: ${{ steps.composer-cache.outputs.dir }}
-                    key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json **/composer.lock') }}
-                    restore-keys: |
-                        ${{ runner.os }}-php-${{ matrix.php }}-composer-
-
-            -
-                name: Install PHP dependencies
-                env:
-                      SYMFONY_REQUIRE: ${{ matrix.symfony-version }}
-                run: |
-                      composer global config --no-plugins allow-plugins.symfony/flex true
-                      composer global require --no-progress --no-scripts --no-plugins symfony/flex
-                      composer update --no-interaction --prefer-dist
+                    dependency-versions: '${{ matrix.deps }}'
+                    composer-options: --no-interaction --prefer-dist
 
             -
                 name: Run analysis

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,27 +16,15 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: [8.3]
+                php: [8.2, 8.3, 8.4]
                 stability: [ prefer-stable ]
-                symfony-version: [ '7.0.*' ]
+                symfony-version: [ '6.4', '7.3' ]
                 include:
-                  - php: '8.1'
-                    symfony-version: 6.4.*
+                  - symfony-version: 6.4
+                    php: '8.1'
                     stability: prefer-lowest
-                  - php: '8.1'
-                    symfony-version: 6.4.*
-                    stability: prefer-stable
-                  - php: '8.2'
-                    symfony-version: 6.4.*
-                    stability: prefer-stable
-                  - php: '8.2'
-                    symfony-version: 7.0.*
-                    stability: prefer-stable
-                  - php: '8.3'
-                    symfony-version: 7.0.*
-                    stability: prefer-stable
-                  - php: '8.4'
-                    symfony-version: 7.0.*
+                  - symfony-version: 6.4
+                    php: '8.1'
                     stability: prefer-stable
 
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+### 7.0.0 (xxx)
+
+ * [PSR-17](https://www.php-fig.org/psr/psr-17/) and [PSR-18](https://www.php-fig.org/psr/psr-18/) implementation
+
 ### 3.0.1 (2020-06-12)
 
  * fixed issue #1 Nullable return type declaration fails with php 7.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### 7.0.0 (xxx)
 
  * [PSR-17](https://www.php-fig.org/psr/psr-17/) and [PSR-18](https://www.php-fig.org/psr/psr-18/) implementation
+ * Drop support for Symfony 7.0, 7.1, 7.2
 
 ### 3.0.1 (2020-06-12)
 

--- a/composer.json
+++ b/composer.json
@@ -21,21 +21,28 @@
         "symfony/serializer": "^6.4 || ^7.0",
         "symfony/property-access": "^6.4 || ^7.0",
         "phpdocumentor/reflection-docblock": "^5.3",
-        "php-http/message-factory": "^1.1"
+        "psr/http-factory": "^1.1",
+        "psr/http-client": "^1.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.49",
         "php-http/cache-plugin": "^2.0",
-        "php-http/guzzle7-adapter": "^1.0",
         "phpunit/phpunit": "^9.6.16",
         "phpunit/phpunit-selenium": "^9.0",
         "symfony/cache": "^6.4 || ^7.0",
+        "symfony/http-client": "^6.4 || ^7.0",
         "symfony/phpunit-bridge": "^6.4 || ^7.0",
-        "ext-json": "*"
+        "ext-json": "*",
+        "nyholm/psr7": "^1.8"
+    },
+    "scripts": {
+        "test": "vendor/bin/phpunit -c phpunit.ci.xml"
     },
     "suggest": {
-        "php-http/client-implementation": "Allows to use http services",
-        "php-http/message": "Allows to use http services"
+        "symfony/http-client": "For a fast PSR-18 client",
+        "php-http/guzzle7-adapter": "For a widely used PSR-18 client",
+        "nyholm/psr7": "Lightweight PSR-7/17 implementation",
+        "php-http/discovery": "To auto-discover installed HTTP clients/factories"
     },
     "replace": {
         "egeloen/google-map": "^2.0.2"

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,9 @@
     ],
     "require": {
         "php": "^8.1",
-        "symfony/event-dispatcher": "^6.4 || ^7.0",
-        "symfony/serializer": "^6.4 || ^7.0",
-        "symfony/property-access": "^6.4 || ^7.0",
+        "symfony/event-dispatcher": "^6.4 || ^7.3",
+        "symfony/serializer": "^6.4 || ^7.3",
+        "symfony/property-access": "^6.4 || ^7.3",
         "phpdocumentor/reflection-docblock": "^5.3",
         "psr/http-factory": "^1.1",
         "psr/http-client": "^1.0"
@@ -29,9 +29,9 @@
         "php-http/cache-plugin": "^2.0",
         "phpunit/phpunit": "^9.6.16",
         "phpunit/phpunit-selenium": "^9.0",
-        "symfony/cache": "^6.4 || ^7.0",
-        "symfony/http-client": "^6.4 || ^7.0",
-        "symfony/phpunit-bridge": "^6.4 || ^7.0",
+        "symfony/cache": "^6.4 || ^7.3",
+        "symfony/http-client": "^6.4 || ^7.3",
+        "symfony/phpunit-bridge": "^6.4 || ^7.3",
         "ext-json": "*",
         "nyholm/psr7": "^1.8"
     },

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -18,18 +18,17 @@ composer require ivory/google-map
 
 ## Download additional libraries
 
-### Httplug
+### PSR-17 and PSR-18
 
-If you want to use a service (geocoder, direction, ...), you will need an http client and message factory via 
-[Httplug](http://httplug.io/) which is an http client abstraction library:
+If you want to use a service (geocoder, direction, ...), you will need an http client and request factory, this bundle is
+built around the [PSR-17](https://www.php-fig.org/psr/psr-17/) and [PSR-18](https://www.php-fig.org/psr/psr-18/) specifications.
+This means that any http client or request factory library which supports these specifications can be used within this bundle.
 
 ``` bash
-composer require php-http/guzzle7-adapter
-composer require php-http/message
+composer require symfony/http-client
 ```
 
-Here, I have chosen to use [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) but since Httplug supports the 
-most popular http clients, you can install your preferred one instead.
+Here, I have chosen to use [HttpClient](https://github.com/symfony/http-client).
 
 ### Ivory Serializer
 

--- a/doc/service/direction/direction.md
+++ b/doc/service/direction/direction.md
@@ -7,9 +7,9 @@ or as latitude/longitude coordinates. The Direction API can return multi-part di
 
 ## Dependencies
 
-The Direction API requires an http client and so, the library relies on [Httplug](http://httplug.io/) which is an http 
-client abstraction library. It also requires the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) in 
-order to deserialize the http response. To install them, read this [documentation](/doc/installation.md).
+The Direction API requires an (PSR-18) http client and (PSR-17) request factory. It also requires the 
+[Ivory Serializer](https://github.com/egeloen/ivory-serializer) in order to deserialize the http response. To install 
+them, read this [documentation](/doc/installation.md).
 
 ## Build
 
@@ -17,15 +17,15 @@ First of all, if you want to route a direction, you will need to build a directi
 
 ``` php
 use Ivory\GoogleMap\Service\Direction\DirectionService;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
-$direction = new DirectionService(new Client(), new GuzzleMessageFactory());
+$direction = new DirectionService(new Psr18Client(), new Psr17Factory());
 ```
 
-The direction constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. Here, 
-I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle message 
-factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
+The direction constructor requires an `HttpClient` as first argument and a `RequestFactory` as second argument. Here, 
+I have chosen to use the [HttpClient](https://github.com/symfony/http-client) client as well as the 
+[Psr7](https://github.com/Nyholm/psr7) request factory.
 
 The direction constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to use it 
 in order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata every time.
@@ -33,12 +33,12 @@ in order to configure a PSR-6 cache pool and so avoid parsing the built-in metad
 ``` php
 use Ivory\GoogleMap\Service\Direction\DirectionService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
 $direction = new DirectionService(
-    new Client(),
-    new GuzzleMessageFactory(),
+    new Psr18Client(),
+    new Psr17Factory(),
     SerializerBuilder::create($psr6Pool)
 );
 ```

--- a/doc/service/distance_matrix/distance_matrix.md
+++ b/doc/service/distance_matrix/distance_matrix.md
@@ -9,9 +9,9 @@ single origin and destination to the [Direction API](/doc/service/direction/dire
 
 ## Dependencies
 
-The Distance Matrix API requires an http client and so, the library relies on [Httplug](http://httplug.io/) which is an 
-http client abstraction library. It also requires the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) 
-in order to deserialize the http response. To install them, read this [documentation](/doc/installation.md).
+The Distance Matrix requires an (PSR-18) http client and (PSR-17) request factory. It also requires the
+[Ivory Serializer](https://github.com/egeloen/ivory-serializer) in order to deserialize the http response. To install
+them, read this [documentation](/doc/installation.md).
 
 ## Build
 
@@ -19,15 +19,15 @@ First of all, if you want to process a distance matrix, you will need to build a
 
 ``` php
 use Ivory\GoogleMap\Service\DistanceMatrix\DistanceMatrixService;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
-$distanceMatrix = new DistanceMatrixService(new Client(), new GuzzleMessageFactory());
+$distanceMatrix = new DistanceMatrixService(new Psr18Client(), new Psr17Factory());
 ```
 
-The distance matrix constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. 
-Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
-message factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
+The distance matrix constructor requires an `HttpClient` as first argument and a `RequestFactory` as second argument. Here,
+I have chosen to use the [HttpClient](https://github.com/symfony/http-client) client as well as the
+[Psr7](https://github.com/Nyholm/psr7) request factory.
 
 The distance matrix constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to 
 use it in order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata every time.  
@@ -35,12 +35,12 @@ use it in order to configure a PSR-6 cache pool and so avoid parsing the built-i
 ``` php
 use Ivory\GoogleMap\Service\DistanceMatrix\DistanceMatrixService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
 $distanceMatrix = new DistanceMatrixService(
-    new Client(),
-    new GuzzleMessageFactory(),
+    new Psr18Client(),
+    new Psr17Factory(),
     SerializerBuilder::create($psr6Pool)
 );
 ```

--- a/doc/service/elevation/elevation.md
+++ b/doc/service/elevation/elevation.md
@@ -6,9 +6,9 @@ routes.
 
 ## Dependencies
 
-The Elevation API requires an http client and so, the library relies on [Httplug](http://httplug.io/) which is an http 
-client abstraction library. It also requires the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) in 
-order to deserialize the http response. To install them, read this [documentation](/doc/installation.md).
+The Elevation API requires an (PSR-18) http client and (PSR-17) request factory. It also requires the
+[Ivory Serializer](https://github.com/egeloen/ivory-serializer) in order to deserialize the http response. To install
+them, read this [documentation](/doc/installation.md).
 
 ## Build
 
@@ -16,15 +16,15 @@ First of all, if you want to process an elevation, you will need to build an ele
 
 ``` php
 use Ivory\GoogleMap\Service\Elevation\ElevationService;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
-$elevation = new ElevationService(new Client(), new GuzzleMessageFactory());
+$elevation = new ElevationService(new Psr18Client(), new Psr17Factory());
 ```
 
-The elevation constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. 
-Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
-message factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
+The elevation constructor requires an `HttpClient` as first argument and a `RequestFactory` as second argument. Here,
+I have chosen to use the [HttpClient](https://github.com/symfony/http-client) client as well as the
+[Psr7](https://github.com/Nyholm/psr7) request factory.
 
 The elevation constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to use it in 
 order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata every time.  
@@ -32,12 +32,12 @@ order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata
 ``` php
 use Ivory\GoogleMap\Service\Elevation\ElevationService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
 $elevation = new ElevationService(
-    new Client(),
-    new GuzzleMessageFactory(),
+    new Psr18Client(),
+    new Psr17Factory(),
     SerializerBuilder::create($psr6Pool)
 );
 ```

--- a/doc/service/geocoder/geocoder.md
+++ b/doc/service/geocoder/geocoder.md
@@ -7,9 +7,9 @@ process is known as "reverse geocoding".
 
 ## Dependencies
 
-The Geocoder API requires an http client and so, the library relies on [Httplug](http://httplug.io/) which is an http 
-client abstraction library. It also requires the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) in 
-order to deserialize the http response. To install them, read this [documentation](/doc/installation.md).
+The Geocoder API requires an (PSR-18) http client and (PSR-17) request factory. It also requires the
+[Ivory Serializer](https://github.com/egeloen/ivory-serializer) in order to deserialize the http response. To install
+them, read this [documentation](/doc/installation.md).
 
 ## Build
 
@@ -17,15 +17,15 @@ First of all, if you want to geocode a position, you will need to build a geocod
 
 ``` php
 use Ivory\GoogleMap\Service\Geocoder\GeocoderService;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
-$geocoder = new GeocoderService(new Client(), new GuzzleMessageFactory());
+$geocoder = new GeocoderService(new Psr18Client(), new Psr17Factory());
 ```
 
-The geocoder constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. Here, 
-I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle message 
-factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
+The geocoder constructor requires an `HttpClient` as first argument and a `RequestFactory` as second argument. Here,
+I have chosen to use the [HttpClient](https://github.com/symfony/http-client) client as well as the
+[Psr7](https://github.com/Nyholm/psr7) request factory.
 
 The geocoder constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to use it in 
 order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata every time.  
@@ -33,12 +33,12 @@ order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata
 ``` php
 use Ivory\GoogleMap\Service\Geocoder\GeocoderService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
 $geocoder = new GeocoderService(
-    new Client(),
-    new GuzzleMessageFactory(),
+    new Psr18Client(),
+    new Psr17Factory(),
     SerializerBuilder::create($psr6Pool)
 );
 ```

--- a/doc/service/place/autocomplete/place_autocomplete.md
+++ b/doc/service/place/autocomplete/place_autocomplete.md
@@ -12,9 +12,9 @@ request for more information about any of the places which are returned.
 
 ## Dependencies
 
-The Place Autocomplete API requires an http client and so, the library relies on [Httplug](http://httplug.io/) which is 
-an http client abstraction library. It also requires the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) 
-in order to deserialize the http response. To install them, read this [documentation](/doc/installation.md).
+The Place Autocomplete API requires an (PSR-18) http client and (PSR-17) request factory. It also requires the
+[Ivory Serializer](https://github.com/egeloen/ivory-serializer) in order to deserialize the http response. To install
+them, read this [documentation](/doc/installation.md).
 
 ## Build
 
@@ -23,15 +23,15 @@ let's go:
 
 ``` php
 use Ivory\GoogleMap\Service\Direction\Place\Autocomplete\PlaceAutocompleteService;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
-$autocomplete = new PlaceAutocompleteService(new Client(), new GuzzleMessageFactory());
+$autocomplete = new PlaceAutocompleteService(new Psr18Client(), new Psr17Factory());
 ```
 
-The Place Autocomplete constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. 
-Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
-message factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
+The direction constructor requires an `HttpClient` as first argument and a `RequestFactory` as second argument. Here,
+I have chosen to use the [HttpClient](https://github.com/symfony/http-client) client as well as the
+[Psr7](https://github.com/Nyholm/psr7) request factory.
 
 The Place Autocomplete constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to 
 use it in order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata every time.  
@@ -39,12 +39,12 @@ use it in order to configure a PSR-6 cache pool and so avoid parsing the built-i
 ``` php
 use Ivory\GoogleMap\Service\Place\Autocomplete\PlaceAutocompleteService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
 $autocomplete = new PlaceAutocompleteService(
-    new Client(),
-    new GuzzleMessageFactory(),
+    new Psr18Client(),
+    new Psr17Factory(),
     SerializerBuilder::create($psr6Pool)
 );
 ```

--- a/doc/service/place/detail/place_detail.md
+++ b/doc/service/place/detail/place_detail.md
@@ -7,9 +7,9 @@ its complete address, phone number, user rating and reviews.
 
 ## Dependencies
 
-The Place Detail API requires an http client and so, the library relies on [Httplug](http://httplug.io/) which is 
-an http client abstraction library. It also requires the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) 
-in order to deserialize the http response. To install them, read this [documentation](/doc/installation.md).
+The Place Detail API requires an (PSR-18) http client and (PSR-17) request factory. It also requires the
+[Ivory Serializer](https://github.com/egeloen/ivory-serializer) in order to deserialize the http response. To install
+them, read this [documentation](/doc/installation.md).
 
 ## Build
 
@@ -17,15 +17,15 @@ First of all, if you want to process a place detail, you will need to build a pl
 
 ``` php
 use Ivory\GoogleMap\Service\Place\Detail\PlaceDetailService;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
-$detail = new PlaceDetailService(new Client(), new GuzzleMessageFactory());
+$detail = new PlaceDetailService(new Psr18Client(), new Psr17Factory());
 ```
 
-The Place Detail constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. 
-Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
-message factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
+The place detail constructor requires an `HttpClient` as first argument and a `RequestFactory` as second argument. Here,
+I have chosen to use the [HttpClient](https://github.com/symfony/http-client) client as well as the
+[Psr7](https://github.com/Nyholm/psr7) request factory.
 
 The Place Detail constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to 
 use it in order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata every time.  
@@ -33,12 +33,12 @@ use it in order to configure a PSR-6 cache pool and so avoid parsing the built-i
 ``` php
 use Ivory\GoogleMap\Service\Place\Detail\PlaceDetailService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
 $detail = new PlaceDetailService(
-    new Client(),
-    new GuzzleMessageFactory(),
+    new Psr18Client(),
+    new Psr17Factory(),
     SerializerBuilder::create($psr6Pool)
 );
 ```

--- a/doc/service/place/photo/place_photo.md
+++ b/doc/service/place/photo/place_photo.md
@@ -19,7 +19,7 @@ $service = new PlacePhotoService();
 
 All services works the same way, so, if you want to learn more about it, you can read this common
 [documentation](/doc/service/service.md) about services except that the place photo service does not use an http client
-and message factory as it does not need to issue http requests.
+and request factory as it does not need to issue http requests.
 
 ## Request
 

--- a/doc/service/place/search/place_search.md
+++ b/doc/service/place/search/place_search.md
@@ -6,9 +6,9 @@ proximity or a text string. A Place Search returns a list of places along with s
 
 ## Dependencies
 
-The Place Search API requires an http client and so, the library relies on [Httplug](http://httplug.io/) which is 
-an http client abstraction library. It also requires the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) 
-in order to deserialize the http response. To install them, read this [documentation](/doc/installation.md).
+The Place Search API requires an (PSR-18) http client and (PSR-17) request factory. It also requires the
+[Ivory Serializer](https://github.com/egeloen/ivory-serializer) in order to deserialize the http response. To install
+them, read this [documentation](/doc/installation.md).
 
 ## Build
 
@@ -16,15 +16,15 @@ First of all, if you want to process a place search, you will need to build a pl
 
 ``` php
 use Ivory\GoogleMap\Service\Place\Search\PlaceSearchService;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
-$search = new PlaceSearchService(new Client(), new GuzzleMessageFactory());
+$search = new PlaceSearchService(new Psr18Client(), new Psr17Factory());
 ```
 
-The Place Search constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. 
-Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle 
-message factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
+The direction constructor requires an `HttpClient` as first argument and a `RequestFactory` as second argument. Here,
+I have chosen to use the [HttpClient](https://github.com/symfony/http-client) client as well as the
+[Psr7](https://github.com/Nyholm/psr7) request factory.
 
 The Place Detail constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to 
 use it in order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata every time.  
@@ -32,12 +32,12 @@ use it in order to configure a PSR-6 cache pool and so avoid parsing the built-i
 ``` php
 use Ivory\GoogleMap\Service\Place\Search\PlaceSearchService;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
 $search = new PlaceSearchService(
-    new Client(),
-    new GuzzleMessageFactory(),
+    new Psr18Client(),
+    new Psr17Factory(),
     SerializerBuilder::create($psr6Pool)
 );
 ```

--- a/doc/service/service.md
+++ b/doc/service/service.md
@@ -7,13 +7,15 @@ All services (direction, distance matrix, geocoder, ...) share common features.
 If you want to update the service http client, you can use:
 
 ``` php
-use Http\Adapter\Guzzle7\Client;
+use Symfony\Component\HttpClient\Psr18Client;
 
-$service->setClient(new Client());
+$service->setClient(new Psr18Client());
 ```
 
-Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client but since 
-[Httplug](http://httplug.io/) supports the most popular http clients, you can choose you preferred one instead.
+Here, I have chosen to use the [HttpClient](https://github.com/symfony/http-client) client, which is probably already 
+available within your project. But since this bundle is built around the [PSR-17](https://www.php-fig.org/psr/psr-17/) 
+and [PSR-18](https://www.php-fig.org/psr/psr-18/) specifications, any library which supports these specifications can 
+be used within this bundle.
 
 ## Configure http plugins
 
@@ -24,6 +26,19 @@ as a better experience with the library. The following are the most interesting 
  - Google Error Plugin: Convert Google invalid responses to exceptions.
  - Retry Plugin: Retry an error responses (exceptions).
  - Cache Plugin: Cache responses using a [PSR-6](http://www.php-fig.org/psr/psr-6/) compliant cache system.
+
+To be able to use the plugins, you need to install [Httplug Bundle](https://packagist.org/packages/php-http/httplug-bundle) 
+and configure them like:
+
+``` yaml
+httplug:
+    classes:
+        client: Symfony\Component\HttpClient\Psr18Client
+        message_factory: Nyholm\Psr7\Factory\Psr17Factory
+    clients:
+        acme:
+            factory: Symfony\Component\HttpClient\Psr18Client
+```
 
 To use these plugins, first install them:
 
@@ -37,21 +52,21 @@ Here, I have chosen to use the Symfony Cache PSR-6 component but you can choose 
 Then, create a plugin client:
 
 ``` php
-use Http\Adapter\Guzzle7\Client;
 use Http\Client\Common\Plugin\CachePlugin;
 use Http\Client\Common\Plugin\ErrorPlugin as HttpErrorPlugin;
 use Http\Client\Common\Plugin\RetryPlugin;
-use Http\Message\StreamFactory\GuzzleStreamFactory;
 use Ivory\GoogleMap\Service\Plugin\ErrorPlugin as GoogleErrorPlugin;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\HttpClient\Psr18Client;
 
-$service->setClient(new PluginClient(new Client(), [
+$service->setClient(new PluginClient(new Psr18Client(), [
     new RetryPlugin(),
     new HttpErrorPlugin(),
     new GoogleErrorPlugin(),
     new CachePlugin(
         new FilesystemAdapter(__DIR__.'/cache'),
-        new GuzzleStreamFactory(),
+        new Psr17Factory(),
         [
             'cache_lifetime'        => null,
             'default_ttl'           => null,
@@ -64,18 +79,19 @@ $service->setClient(new PluginClient(new Client(), [
 In this example, we use the `FilesystemAdapter` as well as an infinite caching strategy but you can configure it 
 according to your needs. 
 
-## Configure message factory
+## Configure request factory
 
-If you want to update the message factory, you can use:
+If you want to update the request factory, you can use:
 
 ``` php
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
-$service->setMessageFactory(new GuzzleMessageFactory());
+$service->setRequestFactory(new Psr17Factory());
 ```
 
-Here, I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) message factory but since 
-[Httplug](http://httplug.io/) supports the most popular http clients, you can choose you preferred one instead.
+Here, I have chosen to use the [Psr7](https://github.com/Nyholm/psr7) request factory. But since this bundle is built 
+around the [PSR-17](https://www.php-fig.org/psr/psr-17/) and [PSR-18](https://www.php-fig.org/psr/psr-18/) 
+specifications, any library which supports these specifications can be used within this bundle.
 
 ## Configure serializer
 

--- a/doc/service/timezone/timezone.md
+++ b/doc/service/timezone/timezone.md
@@ -5,9 +5,9 @@ as that location's time offset from UTC.
 
 ## Dependencies
 
-The TimeZone API requires an http client and so, the library relies on [Httplug](http://httplug.io/) which is an http 
-client abstraction library. It also requires the [Ivory Serializer](https://github.com/egeloen/ivory-serializer) in 
-order to deserialize the http response. To install them, read this [documentation](/doc/installation.md).
+The TimeZone API requires an (PSR-18) http client and (PSR-17) request factory. It also requires the
+[Ivory Serializer](https://github.com/egeloen/ivory-serializer) in order to deserialize the http response. To install
+them, read this [documentation](/doc/installation.md).
 
 ## Build
 
@@ -15,15 +15,15 @@ First of all, if you want to process a timezone, you will need to build a timezo
 
 ``` php
 use Ivory\GoogleMap\Service\TimeZone\TimeZoneService;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
-$timeZone = new TimeZoneService(new Client(), new GuzzleMessageFactory());
+$timeZone = new TimeZoneService(new Psr18Client(), new Psr17Factory());
 ```
 
-The timezone constructor requires an `HttpClient` as first argument and a `MessageFactory` as second argument. Here, 
-I have chosen to use the [Guzzle7](http://docs.guzzlephp.org/en/latest/psr7.html) client as well as the Guzzle message 
-factory. Httplug supports the most popular http clients, so, you can choose you preferred one instead.
+The direction constructor requires an `HttpClient` as first argument and a `RequestFactory` as second argument. Here,
+I have chosen to use the [HttpClient](https://github.com/symfony/http-client) client as well as the
+[Psr7](https://github.com/Nyholm/psr7) request factory.
 
 The timezone constructor also accepts a `SerializerInterface` as third argument. It is highly recommended to use it in 
 order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata every time.  
@@ -31,12 +31,12 @@ order to configure a PSR-6 cache pool and so avoid parsing the built-in metadata
 ``` php
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
 use Ivory\GoogleMap\Service\TimeZone\TimeZoneService;
-use Http\Adapter\Guzzle7\Client;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
+use Symfony\Component\HttpClient\Psr18Client;
+use Nyholm\Psr7\Factory\Psr17Factory;
 
 $timeZone = new TimeZoneService(
-    new Client(),
-    new GuzzleMessageFactory(),
+    new Psr18Client(),
+    new Psr17Factory(),
     SerializerBuilder::create($psr6Pool)
 );
 ```

--- a/src/Service/AbstractHttpService.php
+++ b/src/Service/AbstractHttpService.php
@@ -11,61 +11,45 @@
 
 namespace Ivory\GoogleMap\Service;
 
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface as PsrRequestInterface;
 
-/**
- * @author GeLo <geloen.eric@gmail.com>
- */
 abstract class AbstractHttpService extends AbstractService
 {
-    private HttpClient $client;
-    private MessageFactory $messageFactory;
+    private ClientInterface $client;
+    private RequestFactoryInterface $requestFactory;
 
-    public function __construct(string $url, HttpClient $client, MessageFactory $messageFactory)
+    public function __construct(string $url, ClientInterface $client, RequestFactoryInterface $requestFactory)
     {
         parent::__construct($url);
 
         $this->setClient($client);
-        $this->setMessageFactory($messageFactory);
+        $this->setRequestFactory($requestFactory);
     }
 
-    /**
-     * @return HttpClient
-     */
-    public function getClient()
+    public function getClient(): ClientInterface
     {
         return $this->client;
     }
-    /**
-     * @return void
-     */
-    public function setClient(HttpClient $client)
+
+    public function setClient(ClientInterface $client): void
     {
         $this->client = $client;
     }
 
-    /**
-     * @return MessageFactory
-     */
-    public function getMessageFactory()
+    public function getRequestFactory(): RequestFactoryInterface
     {
-        return $this->messageFactory;
-    }
-    /**
-     * @return void
-     */
-    public function setMessageFactory(MessageFactory $messageFactory)
-    {
-        $this->messageFactory = $messageFactory;
+        return $this->requestFactory;
     }
 
-    /**
-     * @return PsrRequestInterface
-     */
-    protected function createRequest(RequestInterface $request)
+    public function setRequestFactory(RequestFactoryInterface $requestFactory): void
     {
-        return $this->messageFactory->createRequest('GET', $this->createUrl($request));
+        $this->requestFactory = $requestFactory;
+    }
+
+    protected function createRequest(RequestInterface $request): PsrRequestInterface
+    {
+        return $this->requestFactory->createRequest('GET', $this->createUrl($request));
     }
 }

--- a/src/Service/AbstractSerializableService.php
+++ b/src/Service/AbstractSerializableService.php
@@ -11,10 +11,11 @@
 
 namespace Ivory\GoogleMap\Service;
 
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\Serializer\SerializerBuilder;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Symfony\Component\Serializer\SerializerInterface;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Psr\Http\Message\ResponseInterface;
 
 /**
@@ -29,11 +30,11 @@ abstract class AbstractSerializableService extends AbstractHttpService
 
     public function __construct(
         string $url,
-        HttpClient $client,
-        MessageFactory $messageFactory,
+        ClientInterface $client,
+        RequestFactoryInterface $requestFactory,
         ?SerializerInterface $serializer = null
     ) {
-        parent::__construct($url, $client, $messageFactory);
+        parent::__construct($url, $client, $requestFactory);
 
         $this->setSerializer($serializer ?: SerializerBuilder::create());
     }
@@ -68,6 +69,9 @@ abstract class AbstractSerializableService extends AbstractHttpService
         return parent::createBaseUrl($request).'/'.$this->format;
     }
 
+    /**
+     * @throws ExceptionInterface
+     */
     protected function deserialize(ResponseInterface $response, string $type, array $context = []): mixed
     {
         return $this->serializer->deserialize((string) $response->getBody(), $type, $this->format, $context);

--- a/src/Service/Direction/DirectionService.php
+++ b/src/Service/Direction/DirectionService.php
@@ -11,12 +11,13 @@
 
 namespace Ivory\GoogleMap\Service\Direction;
 
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\Direction\Request\DirectionRequestInterface;
 use Ivory\GoogleMap\Service\Direction\Response\DirectionResponse;
 use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -25,15 +26,16 @@ use Symfony\Component\Serializer\SerializerInterface;
 class DirectionService extends AbstractSerializableService
 {
     public function __construct(
-        HttpClient $client,
-        MessageFactory $messageFactory,
+        ClientInterface $client,
+        RequestFactoryInterface $requestFactory,
         ?SerializerInterface $serializer = null
     ) {
-        parent::__construct('https://maps.googleapis.com/maps/api/directions', $client, $messageFactory, $serializer);
+        parent::__construct('https://maps.googleapis.com/maps/api/directions', $client, $requestFactory, $serializer);
     }
 
     /**
      * @throws ClientExceptionInterface
+     * @throws ExceptionInterface
      */
     public function route(DirectionRequestInterface $request): DirectionResponse
     {

--- a/src/Service/DistanceMatrix/DistanceMatrixService.php
+++ b/src/Service/DistanceMatrix/DistanceMatrixService.php
@@ -11,11 +11,13 @@
 
 namespace Ivory\GoogleMap\Service\DistanceMatrix;
 
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\DistanceMatrix\Request\DistanceMatrixRequestInterface;
 use Ivory\GoogleMap\Service\DistanceMatrix\Response\DistanceMatrixResponse;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -24,18 +26,22 @@ use Symfony\Component\Serializer\SerializerInterface;
 class DistanceMatrixService extends AbstractSerializableService
 {
     public function __construct(
-        HttpClient $client,
-        MessageFactory $messageFactory,
+        ClientInterface $client,
+        RequestFactoryInterface $requestFactory,
         ?SerializerInterface $serializer = null
     ) {
         parent::__construct(
             'https://maps.googleapis.com/maps/api/distancematrix',
             $client,
-            $messageFactory,
+            $requestFactory,
             $serializer
         );
     }
 
+    /**
+     * @throws ClientExceptionInterface
+     * @throws ExceptionInterface
+     */
     public function process(DistanceMatrixRequestInterface $request): DistanceMatrixResponse
     {
         $httpRequest = $this->createRequest($request);

--- a/src/Service/Elevation/ElevationService.php
+++ b/src/Service/Elevation/ElevationService.php
@@ -11,11 +11,13 @@
 
 namespace Ivory\GoogleMap\Service\Elevation;
 
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\Elevation\Request\ElevationRequestInterface;
 use Ivory\GoogleMap\Service\Elevation\Response\ElevationResponse;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -24,13 +26,17 @@ use Symfony\Component\Serializer\SerializerInterface;
 class ElevationService extends AbstractSerializableService
 {
     public function __construct(
-        HttpClient $client,
-        MessageFactory $messageFactory,
+        ClientInterface $client,
+        RequestFactoryInterface $requestFactory,
         ?SerializerInterface $serializer = null
     ) {
-        parent::__construct('https://maps.googleapis.com/maps/api/elevation', $client, $messageFactory, $serializer);
+        parent::__construct('https://maps.googleapis.com/maps/api/elevation', $client, $requestFactory, $serializer);
     }
 
+    /**
+     * @throws ClientExceptionInterface
+     * @throws ExceptionInterface
+     */
     public function process(ElevationRequestInterface $request): ElevationResponse
     {
         $httpRequest = $this->createRequest($request);

--- a/src/Service/Geocoder/GeocoderService.php
+++ b/src/Service/Geocoder/GeocoderService.php
@@ -11,11 +11,13 @@
 
 namespace Ivory\GoogleMap\Service\Geocoder;
 
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\Geocoder\Request\GeocoderRequestInterface;
 use Ivory\GoogleMap\Service\Geocoder\Response\GeocoderResponse;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -24,18 +26,22 @@ use Symfony\Component\Serializer\SerializerInterface;
 class GeocoderService extends AbstractSerializableService
 {
     public function __construct(
-        HttpClient $client,
-        MessageFactory $messageFactory,
+        ClientInterface $client,
+        RequestFactoryInterface $requestFactory,
         ?SerializerInterface $serializer = null
     ) {
         parent::__construct(
             'https://maps.googleapis.com/maps/api/geocode',
             $client,
-            $messageFactory,
+            $requestFactory,
             $serializer
         );
     }
 
+    /**
+     * @throws ClientExceptionInterface
+     * @throws ExceptionInterface
+     */
     public function geocode(GeocoderRequestInterface $request): GeocoderResponse
     {
         $httpRequest = $this->createRequest($request);

--- a/src/Service/Place/AbstractPlaceSerializableService.php
+++ b/src/Service/Place/AbstractPlaceSerializableService.php
@@ -11,9 +11,9 @@
 
 namespace Ivory\GoogleMap\Service\Place;
 
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -25,8 +25,8 @@ abstract class AbstractPlaceSerializableService extends AbstractSerializableServ
      * @param string|null $context
      */
     public function __construct(
-        HttpClient $client,
-        MessageFactory $messageFactory,
+        ClientInterface $client,
+        RequestFactoryInterface $requestFactory,
         ?SerializerInterface $serializer = null,
         $context = null
     ) {
@@ -37,7 +37,7 @@ abstract class AbstractPlaceSerializableService extends AbstractSerializableServ
         parent::__construct(
             'https://maps.googleapis.com/maps/api/place'.$context,
             $client,
-            $messageFactory,
+            $requestFactory,
             $serializer
         );
     }

--- a/src/Service/Place/Detail/PlaceDetailService.php
+++ b/src/Service/Place/Detail/PlaceDetailService.php
@@ -11,11 +11,13 @@
 
 namespace Ivory\GoogleMap\Service\Place\Detail;
 
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\Place\Detail\Request\PlaceDetailRequestInterface;
 use Ivory\GoogleMap\Service\Place\Detail\Response\PlaceDetailResponse;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -24,18 +26,22 @@ use Symfony\Component\Serializer\SerializerInterface;
 class PlaceDetailService extends AbstractSerializableService
 {
     public function __construct(
-        HttpClient $client,
-        MessageFactory $messageFactory,
+        ClientInterface $client,
+        RequestFactoryInterface $requestFactory,
         ?SerializerInterface $serializer = null
     ) {
         parent::__construct(
             'https://maps.googleapis.com/maps/api/place/details',
             $client,
-            $messageFactory,
+            $requestFactory,
             $serializer
         );
     }
 
+    /**
+     * @throws ClientExceptionInterface
+     * @throws ExceptionInterface
+     */
     public function process(PlaceDetailRequestInterface $request): PlaceDetailResponse
     {
         $httpRequest = $this->createRequest($request);

--- a/src/Service/TimeZone/TimeZoneService.php
+++ b/src/Service/TimeZone/TimeZoneService.php
@@ -11,11 +11,13 @@
 
 namespace Ivory\GoogleMap\Service\TimeZone;
 
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\TimeZone\Request\TimeZoneRequestInterface;
 use Ivory\GoogleMap\Service\TimeZone\Response\TimeZoneResponse;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -24,13 +26,17 @@ use Symfony\Component\Serializer\SerializerInterface;
 class TimeZoneService extends AbstractSerializableService
 {
     public function __construct(
-        HttpClient $client,
-        MessageFactory $messageFactory,
+        ClientInterface $client,
+        RequestFactoryInterface $requestFactory,
         ?SerializerInterface $serializer = null
     ) {
-        parent::__construct('https://maps.googleapis.com/maps/api/timezone', $client, $messageFactory, $serializer);
+        parent::__construct('https://maps.googleapis.com/maps/api/timezone', $client, $requestFactory, $serializer);
     }
 
+    /**
+     * @throws ClientExceptionInterface
+     * @throws ExceptionInterface
+     */
     public function process(TimeZoneRequestInterface $request): TimeZoneResponse
     {
         $httpRequest = $this->createRequest($request);

--- a/tests/Service/AbstractFunctionalService.php
+++ b/tests/Service/AbstractFunctionalService.php
@@ -11,20 +11,21 @@
 
 namespace Ivory\Tests\GoogleMap\Service;
 
-use Http\Adapter\Guzzle7\Client;
 use Http\Client\Common\Plugin\ErrorPlugin as HttpErrorPlugin;
 use Http\Client\Common\Plugin\HistoryPlugin;
 use Http\Client\Common\Plugin\RetryPlugin;
 use Http\Client\Common\PluginClient;
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
-use Http\Message\MessageFactory\GuzzleMessageFactory;
 use Ivory\GoogleMap\Service\Plugin\ErrorPlugin;
 use Ivory\Tests\GoogleMap\Service\Utility\Journal;
+use Nyholm\Psr7\Factory\Psr17Factory;
 use PHPUnit\Framework\TestCase;
 use Psr\Cache\CacheItemPoolInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Component\HttpClient\Psr18Client;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
@@ -37,14 +38,14 @@ abstract class AbstractFunctionalService extends TestCase
     protected static $journal;
 
     /**
-     * @var HttpClient
+     * @var ClientInterface
      */
     protected $client;
 
     /**
-     * @var MessageFactory
+     * @var RequestFactoryInterface
      */
-    protected $messageFactory;
+    protected $requestFactory;
 
     /**
      * @var CacheItemPoolInterface
@@ -71,9 +72,9 @@ abstract class AbstractFunctionalService extends TestCase
         }
 
         $this->pool = new FilesystemAdapter('', 0, $_SERVER['CACHE_PATH']);
-        $this->messageFactory = new GuzzleMessageFactory();
+        $this->requestFactory = new Psr17Factory();
 
-        $this->client = new PluginClient(new Client(), [
+        $this->client = new PluginClient(new Psr18Client(new MockHttpClient()), [
             new RetryPlugin([
                 'retries'         => 5,
                 'exception_delay' => static function () {

--- a/tests/Service/AbstractUnitService.php
+++ b/tests/Service/AbstractUnitService.php
@@ -11,11 +11,11 @@
 
 namespace Ivory\Tests\GoogleMap\Service;
 
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\BusinessAccount;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
@@ -26,20 +26,11 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 abstract class AbstractUnitService extends TestCase
 {
-    /**
-     * @var HttpClient|MockObject
-     */
-    protected $client;
+    protected ClientInterface|MockObject $client;
 
-    /**
-     * @var MessageFactory|MockObject
-     */
-    protected $messageFactory;
+    protected MockObject|RequestFactoryInterface $requestFactory;
 
-    /**
-     * @var SerializerInterface|MockObject
-     */
-    protected $serializer;
+    protected MockObject|SerializerInterface $serializer;
 
     /**
      * {@inheritdoc}
@@ -47,62 +38,41 @@ abstract class AbstractUnitService extends TestCase
     protected function setUp(): void
     {
         $this->client = $this->createHttpClientMock();
-        $this->messageFactory = $this->createMessageFactoryMock();
+        $this->requestFactory = $this->createRequestFactoryMock();
         $this->serializer = $this->createSerializerMock();
     }
 
-    /**
-     * @return MockObject|HttpClient
-     */
-    protected function createHttpClientMock()
+    protected function createHttpClientMock(): MockObject|ClientInterface
     {
-        return $this->createMock(HttpClient::class);
+        return $this->createMock(ClientInterface::class);
     }
 
-    /**
-     * @return MockObject|MessageFactory
-     */
-    protected function createMessageFactoryMock()
+    protected function createRequestFactoryMock(): RequestFactoryInterface|MockObject
     {
-        return $this->createMock(MessageFactory::class);
+        return $this->createMock(RequestFactoryInterface::class);
     }
 
-    /**
-     * @return MockObject|SerializerInterface
-     */
-    protected function createSerializerMock()
+    protected function createSerializerMock(): SerializerInterface|MockObject
     {
         return $this->createMock(SerializerInterface::class);
     }
 
-    /**
-     * @return MockObject|RequestInterface
-     */
-    protected function createHttpRequestMock()
+    protected function createHttpRequestMock(): RequestInterface|MockObject
     {
         return $this->createMock(RequestInterface::class);
     }
 
-    /**
-     * @return MockObject|ResponseInterface
-     */
-    protected function createHttpResponseMock()
+    protected function createHttpResponseMock(): ResponseInterface|MockObject
     {
         return $this->createMock(ResponseInterface::class);
     }
 
-    /**
-     * @return MockObject|StreamInterface
-     */
-    protected function createHttpStreamMock()
+    protected function createHttpStreamMock(): StreamInterface|MockObject
     {
         return $this->createMock(StreamInterface::class);
     }
 
-    /**
-     * @return MockObject|BusinessAccount
-     */
-    protected function createBusinessAccountMock()
+    protected function createBusinessAccountMock(): MockObject|BusinessAccount
     {
         return $this->createMock(BusinessAccount::class);
     }

--- a/tests/Service/Direction/DirectionServiceTest.php
+++ b/tests/Service/Direction/DirectionServiceTest.php
@@ -56,7 +56,7 @@ class DirectionServiceTest extends AbstractSerializableService
 
         parent::setUp();
 
-        $this->service = new DirectionService($this->client, $this->messageFactory);
+        $this->service = new DirectionService($this->client, $this->requestFactory);
         $this->service->setKey($_SERVER['API_KEY']);
     }
 

--- a/tests/Service/DistanceMatrix/DistanceMatrixServiceTest.php
+++ b/tests/Service/DistanceMatrix/DistanceMatrixServiceTest.php
@@ -49,7 +49,7 @@ class DistanceMatrixServiceTest extends AbstractSerializableService
 
         parent::setUp();
 
-        $this->service = new DistanceMatrixService($this->client, $this->messageFactory);
+        $this->service = new DistanceMatrixService($this->client, $this->requestFactory);
         $this->service->setKey($_SERVER['API_KEY']);
     }
 

--- a/tests/Service/DistanceMatrix/DistanceMatrixServiceUnitTest.php
+++ b/tests/Service/DistanceMatrix/DistanceMatrixServiceUnitTest.php
@@ -36,7 +36,7 @@ class DistanceMatrixServiceUnitTest extends AbstractUnitService
 
         $this->service = new DistanceMatrixService(
             $this->client,
-            $this->messageFactory,
+            $this->requestFactory,
             $this->serializer
         );
     }
@@ -51,7 +51,7 @@ class DistanceMatrixServiceUnitTest extends AbstractUnitService
 
         $url = 'https://maps.googleapis.com/maps/api/distancematrix/json?foo=bar&signature=signature';
 
-        $this->messageFactory
+        $this->requestFactory
             ->expects($this->once())
             ->method('createRequest')
             ->with(

--- a/tests/Service/Elevation/ElevationServiceTest.php
+++ b/tests/Service/Elevation/ElevationServiceTest.php
@@ -45,7 +45,7 @@ class ElevationServiceTest extends AbstractSerializableService
 
         parent::setUp();
 
-        $this->service = new ElevationService($this->client, $this->messageFactory);
+        $this->service = new ElevationService($this->client, $this->requestFactory);
         $this->service->setKey($_SERVER['API_KEY']);
     }
 

--- a/tests/Service/Elevation/ElevationServiceUnitTest.php
+++ b/tests/Service/Elevation/ElevationServiceUnitTest.php
@@ -36,7 +36,7 @@ class ElevationServiceUnitTest extends AbstractUnitService
 
         $this->service = new ElevationService(
             $this->client,
-            $this->messageFactory,
+            $this->requestFactory,
             $this->serializer
         );
     }
@@ -51,7 +51,7 @@ class ElevationServiceUnitTest extends AbstractUnitService
 
         $url = 'https://maps.googleapis.com/maps/api/elevation/json?foo=bar&signature=signature';
 
-        $this->messageFactory
+        $this->requestFactory
             ->expects($this->once())
             ->method('createRequest')
             ->with(

--- a/tests/Service/Geocoder/GeocoderServiceTest.php
+++ b/tests/Service/Geocoder/GeocoderServiceTest.php
@@ -45,7 +45,7 @@ class GeocoderServiceTest extends AbstractSerializableService
 
         parent::setUp();
 
-        $this->service = new GeocoderService($this->client, $this->messageFactory);
+        $this->service = new GeocoderService($this->client, $this->requestFactory);
         $this->service->setKey($_SERVER['API_KEY']);
     }
 

--- a/tests/Service/Geocoder/GeocoderServiceUnitTest.php
+++ b/tests/Service/Geocoder/GeocoderServiceUnitTest.php
@@ -36,7 +36,7 @@ class GeocoderServiceUnitTest extends AbstractUnitService
 
         $this->service = new GeocoderService(
             $this->client,
-            $this->messageFactory,
+            $this->requestFactory,
             $this->serializer
         );
     }
@@ -51,7 +51,7 @@ class GeocoderServiceUnitTest extends AbstractUnitService
 
         $url = 'https://maps.googleapis.com/maps/api/geocode/json?foo=bar&signature=signature';
 
-        $this->messageFactory
+        $this->requestFactory
             ->expects($this->once())
             ->method('createRequest')
             ->with(

--- a/tests/Service/HttpServiceTest.php
+++ b/tests/Service/HttpServiceTest.php
@@ -11,37 +11,22 @@
 
 namespace Ivory\Tests\GoogleMap\Service;
 
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractHttpService;
 use Ivory\GoogleMap\Service\AbstractService;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 
 /**
  * @author GeLo <geloen.eric@gmail.com>
  */
 class HttpServiceTest extends TestCase
 {
-    /**
-     * @var AbstractHttpService|MockObject
-     */
-    private $service;
-
-    /**
-     * @var string
-     */
-    private $url;
-
-    /**
-     * @var HttpClient|MockObject
-     */
-    private $client;
-
-    /**
-     * @var MessageFactory|MockObject
-     */
-    private $messageFactory;
+    private MockObject|AbstractHttpService $service;
+    private string $url;
+    private ClientInterface|MockObject $client;
+    private MockObject|RequestFactoryInterface $requestFactory;
 
     /**
      * {@inheritdoc}
@@ -52,7 +37,7 @@ class HttpServiceTest extends TestCase
             ->setConstructorArgs([
                 $this->url = 'https://foo',
                 $this->client = $this->createHttpClientMock(),
-                $this->messageFactory = $this->createMessageFactoryMock(),
+                $this->requestFactory = $this->createRequestFactoryMock(),
             ])
             ->getMockForAbstractClass();
     }
@@ -62,7 +47,7 @@ class HttpServiceTest extends TestCase
         $this->assertInstanceOf(AbstractService::class, $this->service);
         $this->assertSame('https://foo', $this->service->getUrl());
         $this->assertSame($this->client, $this->service->getClient());
-        $this->assertSame($this->messageFactory, $this->service->getMessageFactory());
+        $this->assertSame($this->requestFactory, $this->service->getRequestFactory());
     }
 
     public function testClient()
@@ -72,26 +57,20 @@ class HttpServiceTest extends TestCase
         $this->assertSame($client, $this->service->getClient());
     }
 
-    public function testMessageFactory()
+    public function testRequestFactory()
     {
-        $this->service->setMessageFactory($messageFactory = $this->createMessageFactoryMock());
+        $this->service->setRequestFactory($requestFactory = $this->createRequestFactoryMock());
 
-        $this->assertSame($messageFactory, $this->service->getMessageFactory());
+        $this->assertSame($requestFactory, $this->service->getRequestFactory());
     }
 
-    /**
-     * @return MockObject|HttpClient
-     */
-    private function createHttpClientMock()
+    private function createHttpClientMock(): ClientInterface|MockObject
     {
-        return $this->createMock(HttpClient::class);
+        return $this->createMock(ClientInterface::class);
     }
 
-    /**
-     * @return MockObject|MessageFactory
-     */
-    private function createMessageFactoryMock()
+    private function createRequestFactoryMock(): RequestFactoryInterface|MockObject
     {
-        return $this->createMock(MessageFactory::class);
+        return $this->createMock(RequestFactoryInterface::class);
     }
 }

--- a/tests/Service/Place/Autocomplete/PlaceAutocompleteServiceTest.php
+++ b/tests/Service/Place/Autocomplete/PlaceAutocompleteServiceTest.php
@@ -47,7 +47,7 @@ class PlaceAutocompleteServiceTest extends AbstractPlaceSerializableService
 
         parent::setUp();
 
-        $this->service = new PlaceAutocompleteService($this->client, $this->messageFactory);
+        $this->service = new PlaceAutocompleteService($this->client, $this->requestFactory);
         $this->service->setKey($_SERVER['API_KEY']);
     }
 

--- a/tests/Service/Place/Autocomplete/PlaceAutocompleteServiceUnitTest.php
+++ b/tests/Service/Place/Autocomplete/PlaceAutocompleteServiceUnitTest.php
@@ -36,7 +36,7 @@ class PlaceAutocompleteServiceUnitTest extends AbstractUnitService
 
         $this->service = new PlaceAutocompleteService(
             $this->client,
-            $this->messageFactory,
+            $this->requestFactory,
             $this->serializer
         );
     }
@@ -56,7 +56,7 @@ class PlaceAutocompleteServiceUnitTest extends AbstractUnitService
 
         $url = 'https://maps.googleapis.com/maps/api/place/'.$context.'/json?foo=bar&signature=signature';
 
-        $this->messageFactory
+        $this->requestFactory
             ->expects($this->once())
             ->method('createRequest')
             ->with(

--- a/tests/Service/Place/Detail/PlaceDetailServiceTest.php
+++ b/tests/Service/Place/Detail/PlaceDetailServiceTest.php
@@ -40,7 +40,7 @@ class PlaceDetailServiceTest extends AbstractPlaceSerializableService
 
         parent::setUp();
 
-        $this->service = new PlaceDetailService($this->client, $this->messageFactory);
+        $this->service = new PlaceDetailService($this->client, $this->requestFactory);
         $this->service->setKey($_SERVER['API_KEY']);
     }
 

--- a/tests/Service/Place/Detail/PlaceDetailServiceUnitTest.php
+++ b/tests/Service/Place/Detail/PlaceDetailServiceUnitTest.php
@@ -36,7 +36,7 @@ class PlaceDetailServiceUnitTest extends AbstractUnitService
 
         $this->service = new PlaceDetailService(
             $this->client,
-            $this->messageFactory,
+            $this->requestFactory,
             $this->serializer
         );
     }
@@ -51,7 +51,7 @@ class PlaceDetailServiceUnitTest extends AbstractUnitService
 
         $url = 'https://maps.googleapis.com/maps/api/place/details/json?foo=bar&signature=signature';
 
-        $this->messageFactory
+        $this->requestFactory
             ->expects($this->once())
             ->method('createRequest')
             ->with(

--- a/tests/Service/Place/Search/PlaceSearchServiceTest.php
+++ b/tests/Service/Place/Search/PlaceSearchServiceTest.php
@@ -51,7 +51,7 @@ class PlaceSearchServiceTest extends AbstractPlaceSerializableService
             sleep(5);
         }
 
-        $this->service = new PlaceSearchService($this->client, $this->messageFactory);
+        $this->service = new PlaceSearchService($this->client, $this->requestFactory);
         $this->service->setKey($_SERVER['API_KEY']);
     }
 

--- a/tests/Service/Place/Search/PlaceSearchServiceUnitTest.php
+++ b/tests/Service/Place/Search/PlaceSearchServiceUnitTest.php
@@ -36,7 +36,7 @@ class PlaceSearchServiceUnitTest extends AbstractUnitService
 
         $this->service = new PlaceSearchService(
             $this->client,
-            $this->messageFactory,
+            $this->requestFactory,
             $this->serializer
         );
     }
@@ -56,7 +56,7 @@ class PlaceSearchServiceUnitTest extends AbstractUnitService
 
         $url = 'https://maps.googleapis.com/maps/api/place/'.$context.'/json?foo=bar&signature=signature';
 
-        $this->messageFactory
+        $this->requestFactory
             ->expects($this->once())
             ->method('createRequest')
             ->with(

--- a/tests/Service/SerializableServiceTest.php
+++ b/tests/Service/SerializableServiceTest.php
@@ -11,13 +11,13 @@
 
 namespace Ivory\Tests\GoogleMap\Service;
 
-use Http\Client\HttpClient;
-use Http\Message\MessageFactory;
 use Ivory\GoogleMap\Service\AbstractHttpService;
 use Ivory\GoogleMap\Service\AbstractSerializableService;
 use Ivory\GoogleMap\Service\BusinessAccount;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
 use Symfony\Component\Serializer\SerializerInterface;
 
 /**
@@ -25,30 +25,15 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class SerializableServiceTest extends TestCase
 {
-    /**
-     * @var AbstractSerializableService|MockObject
-     */
-    private $service;
+    private AbstractSerializableService|MockObject $service;
 
-    /**
-     * @var string
-     */
-    private $url;
+    private string $url;
 
-    /**
-     * @var HttpClient|MockObject
-     */
-    private $client;
+    private ClientInterface|MockObject $client;
 
-    /**
-     * @var MessageFactory|MockObject
-     */
-    private $messageFactory;
+    private MockObject|RequestFactoryInterface $requestFactory;
 
-    /**
-     * @var SerializerInterface|MockObject
-     */
-    private $serializer;
+    private MockObject|SerializerInterface $serializer;
 
     /**
      * {@inheritdoc}
@@ -59,7 +44,7 @@ class SerializableServiceTest extends TestCase
             ->setConstructorArgs([
                 $this->url = 'https://foo',
                 $this->client = $this->createHttpClientMock(),
-                $this->messageFactory = $this->createMessageFactoryMock(),
+                $this->requestFactory = $this->createRequestFactoryMock(),
                 $this->serializer = $this->createSerializerMock(),
             ])
             ->getMockForAbstractClass();
@@ -74,7 +59,7 @@ class SerializableServiceTest extends TestCase
     {
         $this->assertSame('https://foo', $this->service->getUrl());
         $this->assertSame($this->client, $this->service->getClient());
-        $this->assertSame($this->messageFactory, $this->service->getMessageFactory());
+        $this->assertSame($this->requestFactory, $this->service->getRequestFactory());
         $this->assertSame($this->serializer, $this->service->getSerializer());
         $this->assertFalse($this->service->hasKey());
         $this->assertNull($this->service->getKey());
@@ -94,11 +79,11 @@ class SerializableServiceTest extends TestCase
         $this->assertSame($client, $this->service->getClient());
     }
 
-    public function testMessageFactory()
+    public function testRequestFactory()
     {
-        $this->service->setMessageFactory($messageFactory = $this->createMessageFactoryMock());
+        $this->service->setRequestFactory($requestFactory = $this->createRequestFactoryMock());
 
-        $this->assertSame($messageFactory, $this->service->getMessageFactory());
+        $this->assertSame($requestFactory, $this->service->getRequestFactory());
     }
 
     public function testSerializer()
@@ -142,34 +127,22 @@ class SerializableServiceTest extends TestCase
         $this->assertNull($this->service->getBusinessAccount());
     }
 
-    /**
-     * @return MockObject|HttpClient
-     */
-    private function createHttpClientMock()
+    private function createHttpClientMock(): MockObject|ClientInterface
     {
-        return $this->createMock(HttpClient::class);
+        return $this->createMock(ClientInterface::class);
     }
 
-    /**
-     * @return MockObject|MessageFactory
-     */
-    private function createMessageFactoryMock()
+    private function createRequestFactoryMock(): RequestFactoryInterface|MockObject
     {
-        return $this->createMock(MessageFactory::class);
+        return $this->createMock(RequestFactoryInterface::class);
     }
 
-    /**
-     * @return MockObject|SerializerInterface
-     */
-    private function createSerializerMock()
+    private function createSerializerMock(): SerializerInterface|MockObject
     {
         return $this->createMock(SerializerInterface::class);
     }
 
-    /**
-     * @return MockObject|BusinessAccount
-     */
-    private function createBusinessAccountMock()
+    private function createBusinessAccountMock(): MockObject|BusinessAccount
     {
         return $this->createMock(BusinessAccount::class);
     }

--- a/tests/Service/TimeZone/TimeZoneServiceApiKeyTest.php
+++ b/tests/Service/TimeZone/TimeZoneServiceApiKeyTest.php
@@ -41,7 +41,7 @@ class TimeZoneServiceApiKeyTest extends AbstractSerializableService
 
         parent::setUp();
 
-        $this->service = new TimeZoneService($this->client, $this->messageFactory);
+        $this->service = new TimeZoneService($this->client, $this->requestFactory);
         $this->service->setKey($_SERVER['API_KEY']);
     }
 

--- a/tests/Service/TimeZone/TimeZoneServiceUnitTest.php
+++ b/tests/Service/TimeZone/TimeZoneServiceUnitTest.php
@@ -36,7 +36,7 @@ class TimeZoneServiceUnitTest extends AbstractUnitService
 
         $this->service = new TimeZoneService(
             $this->client,
-            $this->messageFactory,
+            $this->requestFactory,
             $this->serializer
         );
     }
@@ -51,7 +51,7 @@ class TimeZoneServiceUnitTest extends AbstractUnitService
 
         $url = 'https://maps.googleapis.com/maps/api/timezone/json?foo=bar&signature=signature';
 
-        $this->messageFactory
+        $this->requestFactory
             ->expects($this->once())
             ->method('createRequest')
             ->with(


### PR DESCRIPTION
Fixes the `Package php-http/message-factory is abandoned, you should avoid using it. Use psr/http-factory instead.` message. 

Changes:
- Replaced `Http\Message\MessageFactory` with `Psr\Http\Message\RequestFactoryInterface`
- Replaced `Http\Client\HttpClient` with `Psr\Http\Client\ClientInterface`
- Dropped references to [Httplug](https://httplug.io/) as it's not needed anymore with full PSR-17 and PSR-18 compatibility, also simplifies configuration.

When merged and a new release is available I will update the version requirement in https://github.com/bresam/ivory-google-map-bundle/pull/33.

All feedback is welcome :)